### PR TITLE
Fixed Upcoming Matches not updating

### DIFF
--- a/api/api/api.go
+++ b/api/api/api.go
@@ -295,7 +295,7 @@ func (a *API) PopulateMatches() error {
 		return err
 	}
 
-	// Populate Match Results
+	// Populate Match Results -> due to some spaghetti code, this also populates match schedule
 	_, err = a.Store.GetMatchResults()
 	if err != nil {
 		return err

--- a/api/store/match_results.go
+++ b/api/store/match_results.go
@@ -129,14 +129,6 @@ func (s *Store) GetMatchResults() (external.MatchResult, error) {
 			return nil, err
 		}
 
-		// Update Scheduled matches
-		// This probably isnt the best place to do this, but it is stopping us from needing another api call for the same data
-		// Its also not a concrete fix as you need to run $check or $leaderboard to get the latest scheduled matches
-		err = s.StoreMatchSchedule(upcomingMatches)
-		if err != nil {
-			return nil, err
-		}
-
 		return externalResults, nil
 	}
 

--- a/api/store/match_schedule.go
+++ b/api/store/match_schedule.go
@@ -74,17 +74,18 @@ func (s *Store) StoreMatchSchedule(scheduledMatches []external.ScheduledMatch) e
 
 	// Create bson UpcomingMatchDoc
 	filter := bson.M{"round": s.Round}
-	update := bson.M{"$set": UpcomingMatchDoc {
+	upcomingMatchDoc := UpcomingMatchDoc {
 		Round: s.Round,
 		ScheduledMatches: scheduledMatches,
 		TTL : DetermineTTL(scheduledMatches),
-	}}
+	}
+	update := bson.M{"$set": upcomingMatchDoc}
 
 	fmt.Println("updating match schedule in db...")
 
 	// Perform insert or update
 	if notFound {
-		_, err := s.Collections.MatchSchedule.InsertOne(context.TODO(), UpcomingMatchDoc{Round: s.Round, ScheduledMatches: scheduledMatches})
+		_, err := s.Collections.MatchSchedule.InsertOne(context.TODO(), upcomingMatchDoc)
 		if err != nil {
 			return fmt.Errorf("failed to insert upcoming matches: %w", err)
 		}

--- a/api/store/match_schedule.go
+++ b/api/store/match_schedule.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"pickems-bot/api/external"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -24,12 +26,29 @@ func (s *Store) FetchMatchSchedule() ([]external.ScheduledMatch, error){
 	
 	// Get UpcomingMatchDoc result from db
 	var res UpcomingMatchDoc
+	var shouldRefresh bool
 	err := s.Collections.MatchSchedule.FindOne(context.TODO(), bson.D{{Key: "round", Value: s.Round}}, opts).Decode(&res)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, fmt.Errorf("no results found in db")
+			shouldRefresh = true
 		}
 		return nil, fmt.Errorf("error fetching results from db: %w", err)
+	} else if res.TTL < time.Now().Unix() {
+		shouldRefresh = true
+	}
+
+	// Run if we need to refresh the data stored in the db (either there is no data stored or the TTL has experied)
+	if shouldRefresh {
+		// get new data from liquipediadb api
+		externalResults, err := external.FetchScheduledMatches(os.Getenv("LIQUIDPEDIADB_API_KEY"), s.Page, s.OptionalParams)
+		if err != nil {
+			return nil, err
+		}
+		err = s.StoreMatchSchedule(externalResults)
+		if err != nil {
+			return nil, err
+		}
+		return externalResults, nil
 	}
 
 	return res.ScheduledMatches, nil
@@ -58,6 +77,7 @@ func (s *Store) StoreMatchSchedule(scheduledMatches []external.ScheduledMatch) e
 	update := bson.M{"$set": UpcomingMatchDoc {
 		Round: s.Round,
 		ScheduledMatches: scheduledMatches,
+		TTL : DetermineTTL(scheduledMatches),
 	}}
 
 	fmt.Println("updating match schedule in db...")

--- a/api/store/match_schedule_test.go
+++ b/api/store/match_schedule_test.go
@@ -22,7 +22,7 @@ func NewTestStore(t *testing.T, round string) *Store {
 	}
 
 	db := client.Database("test")
-	coll := db.Collection("match_schedule_test")
+	coll := db.Collection("scheduled_matches")
 	_ = coll.Drop(context.TODO()) // clear before test
 
 	s := &Store{

--- a/api/store/match_schedule_test.go
+++ b/api/store/match_schedule_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"context"
+	"pickems-bot/api/external"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func NewTestStore(t *testing.T, round string) *Store {
+	t.Helper()
+
+	mongoUri := "mongodb://192.168.1.105:27017/?directConnection=true&serverSelectionTimeoutMS=2000"
+	
+	clientOpts := options.Client().ApplyURI(mongoUri)
+	client, err := mongo.Connect(context.TODO(), clientOpts)
+	if err != nil {
+		t.Fatalf("Failed to connect to MongoDB: %v", err)
+	}
+
+	db := client.Database("test")
+	coll := db.Collection("match_schedule_test")
+	_ = coll.Drop(context.TODO()) // clear before test
+
+	s := &Store{
+		Client:   client,
+		Database: db,
+		Round:    round,
+	}
+
+	s.Collections.MatchSchedule = coll
+	return s
+}
+
+func TestStoreMatchSchedule_Update(t *testing.T) {
+	store := NewTestStore(t, "test-round")
+	
+	original := []external.ScheduledMatch {
+	{Team1: "TBD", Team2: "TBD", EpochTime: -62167219200, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	{Team1: "TBD", Team2: "TBD", EpochTime: -62167219200, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	{Team1: "FURIA", Team2: "PaiN Gaming", EpochTime: 1750359600, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	{Team1: "Team Spirit", Team2: "MOUZ", EpochTime: 1750375800, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	{Team1: "FaZe Clan", Team2: "The MongolZ", EpochTime: 1750442400, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	{Team1: "Natus Vincere", Team2: "Team Vitality", EpochTime: 1750458600, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	{Team1: "TBD", Team2: "TBD", EpochTime: 1750620600, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	}
+
+	if err := store.StoreMatchSchedule(original); err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	updated := []external.ScheduledMatch {
+		{Team1: "Team Spirit", Team2: "Team Vitality", EpochTime: -62167219200, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+		{Team1: "FaZe Clan", Team2: "FURIA", EpochTime: -62167219200, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+		{Team1: "FURIA", Team2: "PaiN Gaming", EpochTime: 1750359600, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: true},
+		{Team1: "Team Spirit", Team2: "MOUZ", EpochTime: 1750375800, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: true},
+		{Team1: "FaZe Clan", Team2: "The MongolZ", EpochTime: 1750442400, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: true},
+		{Team1: "Natus Vincere", Team2: "Team Vitality", EpochTime: 1750458600, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: true},
+		{Team1: "TBD", Team2: "TBD", EpochTime: 1750620600, BestOf: "3", StreamUrl: "BLAST_Premier", Finished: false},
+	}
+	if err := store.StoreMatchSchedule(updated); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	var result UpcomingMatchDoc
+	err := store.Collections.MatchSchedule.FindOne(context.TODO(), bson.M{"round": "test-round"}).Decode(&result)
+	if err != nil {
+		t.Fatalf("Fetch after update failed: %v", err)
+	}
+}

--- a/api/store/models.go
+++ b/api/store/models.go
@@ -100,6 +100,7 @@ func (e EliminationResultRecord) GetTeams() map[string]interface{} {
 type UpcomingMatchDoc struct {
 	Round string `bson:"round,omitempty"`
 	ScheduledMatches []external.ScheduledMatch `bson:"scheduled_matches,omitempty"`
+	TTL int64 `bson:"ttl,omitempty"`
 }
 
 // Function to convert RecordResult interface to MatchResult interface. Used when getting data from the db


### PR DESCRIPTION
Previously, upcoming matches was never updated unless the program was restarted.
- This PR updates this by giving the scheduled_matches documents a TTL with the same logic as match_results documents, this way if new upcoming matches are detected, the program can use these
- This PR also adds a testing file for match_schedule as originally the `StoreMatchSchedule` function was thought to be the culprit of this issue