### PR TITLE
Upcoming bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 /pickems-bot
+.idea

--- a/api/api/api.go
+++ b/api/api/api.go
@@ -282,7 +282,7 @@ func (a *API) GetTournamentInfo() ([]string, error) {
 // Function to fetch scheduled match data and store it in the DB. Needs to be run before other functions in this package will work properly
 // Preconditions: Receives receiver pointer to API
 // Postconditions: Returns nil, or an error if it occurs
-func (a *API) PopulateMatches() error {
+func (a *API) PopulateMatches(scheduleOnly bool) error {
 	// Populated Scheduled matches
 	scheduledMatches, err := external.FetchScheduledMatches(os.Getenv("LIQUIDPEDIADB_API_KEY"), a.Store.Page, a.Store.OptionalParams)
 	if err != nil {
@@ -295,12 +295,13 @@ func (a *API) PopulateMatches() error {
 		return err
 	}
 
-	// Populate Match Results -> due to some spaghetti code, this also populates match schedule
-	_, err = a.Store.GetMatchResults()
-	if err != nil {
-		return err
+	if !scheduleOnly { // Only run if scheduleOnly is false, this way we can store upcoming matches of unsupported match structures
+		// Populate Match Results -> due to some spaghetti code, this also populates match schedule
+		_, err = a.Store.GetMatchResults()
+		if err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 

--- a/api/external/external.go
+++ b/api/external/external.go
@@ -21,7 +21,7 @@ import (
 // Returns slice of Scheduled matches or an error if it occurs
 func FetchScheduledMatches(apiKey string, page string, optionalParams string) ([]ScheduledMatch, error) {
 	url := fmt.Sprintf("https://liquipedia.net/counterstrike/%s?action=raw%s", page, optionalParams)
-	
+
 	// Get wikitext
 	wikitext, err := GetWikitext(url)
 	if err != nil {
@@ -59,17 +59,17 @@ func FetchScheduledMatches(apiKey string, page string, optionalParams string) ([
 // (e.g. https://liquipedia.net/counterstrike/PGL/2024/Copenhagen/Opening_Stage?action=raw)
 // Postconditions: Returns string containing raw wiki text and errors
 func GetWikitext(url string) (string, error) {
-	
+
 	// Create HTTP Request
 	client := &http.Client{}
-	request, err :=  http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		fmt.Println("Failed to create request", err)
 	}
 
 	// Headers to apply with API requirements
 	request.Header.Set("User-Agent", "LiquipediaDataFetcher/1.0")
-    request.Header.Set("Accept-Encoding", "gzip")
+	request.Header.Set("Accept-Encoding", "gzip")
 
 	response, err := client.Do(request)
 	if err != nil {
@@ -100,7 +100,7 @@ func GetWikitext(url string) (string, error) {
 	}
 
 	if err != nil {
-		fmt.Println("Failed to read response body:",err)
+		fmt.Println("Failed to read response body:", err)
 		return "", err
 	}
 
@@ -124,7 +124,7 @@ func GetLiquipediaMatchData(apiKey string, bracketIds []string) (string, error) 
 	// Convert tournalmentUrl string into url so we can add params
 	parsedUrl, err := url.Parse(apiUrl)
 	if err != nil {
-		fmt.Println("Invalid url:",err)
+		fmt.Println("Invalid url:", err)
 		return "", err
 	}
 
@@ -139,10 +139,10 @@ func GetLiquipediaMatchData(apiKey string, bracketIds []string) (string, error) 
 
 	// Create HTTP Request
 	client := &http.Client{}
-	request, err :=  http.NewRequest("GET", parsedUrl.String(), nil)
+	request, err := http.NewRequest("GET", parsedUrl.String(), nil)
 	if err != nil {
 		fmt.Println("Failed to create request", err)
-		return "", err;
+		return "", err
 	}
 
 	// Apply auth header to request

--- a/api/external/parser.go
+++ b/api/external/parser.go
@@ -36,10 +36,10 @@ func GetMatchNodesFromJson(matchData string) ([]MatchNode, error) {
 	for _, result := range rawResults {
 		node, err := ParseMatchData(result)
 		if err != nil {
-			fmt.Println("Error creating match node:",err)
+			fmt.Println("Error creating match node:", err)
 			return nil, err
 		}
-		matchNodes = append(matchNodes, *node)	
+		matchNodes = append(matchNodes, *node)
 	}
 	return matchNodes, nil
 }
@@ -63,15 +63,15 @@ func GetScheduledMatchesFromJson(matchData string) ([]ScheduledMatch, error) {
 	for _, result := range rawResults {
 		match, err := ParseScheduledMatches(result)
 		if err != nil {
-			fmt.Println("Error creating match node:",err)
+			fmt.Println("Error creating match node:", err)
 			return nil, err
 		}
 		// Match and error will only ever be both nil if there is no upcoming match
 		if match == nil {
 			continue
 		}
-		
-		upcomingMatches = append(upcomingMatches, *match)	
+
+		upcomingMatches = append(upcomingMatches, *match)
 	}
 	return upcomingMatches, nil
 }
@@ -125,7 +125,7 @@ func ParseMatchData(result interface{}) (*MatchNode, error) {
 		}
 		teams[i] = name
 	}
-	
+
 	// If the match has finished, get the name of the team that won, else set as TBD
 	winner := "TBD"
 	if isFinished {
@@ -141,9 +141,9 @@ func ParseMatchData(result interface{}) (*MatchNode, error) {
 	}
 
 	return &MatchNode{
-		Id: matchIdStr,
-		Team1: teams[0],
-		Team2: teams[1],
+		Id:     matchIdStr,
+		Team1:  teams[0],
+		Team2:  teams[1],
 		Winner: winner,
 	}, nil
 }
@@ -158,12 +158,12 @@ func CalculateSwissScores(matchNodes []MatchNode) (map[string]string, error) {
 
 	for i := range matchNodes {
 		node := matchNodes[i]
-		
+
 		// Check if teams are in teams slice
 		if !slices.Contains(teams, node.Team1) {
 			teams = append(teams, node.Team1)
 		}
-		if ! slices.Contains(teams, node.Team2) {
+		if !slices.Contains(teams, node.Team2) {
 			teams = append(teams, node.Team2)
 		}
 
@@ -181,7 +181,7 @@ func CalculateSwissScores(matchNodes []MatchNode) (map[string]string, error) {
 			// Unexpected winner value skip
 			continue
 		}
-	
+
 	}
 
 	scores := make(map[string]string)
@@ -203,7 +203,7 @@ func GetEliminationResults(matchNodes []MatchNode) (map[string]shared.TeamProgre
 	if len(matchNodes) == 0 {
 		return nil, fmt.Errorf("at least one match required, recieved 0")
 	}
-	
+
 	// Ordered slice of rounds where [0] is the last match (grand final), and [n] is the first. This is where the limitation of 32 comes from
 	rounds, err := getRoundNames(len(matchNodes))
 	if err != nil {
@@ -264,7 +264,7 @@ func GetEliminationResults(matchNodes []MatchNode) (map[string]shared.TeamProgre
 	return results, nil
 }
 
-// Helper function to get the index of a round from its name. Used in GetEliminationResults 
+// Helper function to get the index of a round from its name. Used in GetEliminationResults
 // Preconditions: Receives a string, and slice of strings
 // Postconditions: Returns the index of that string in the slice, or -1 if not found
 func getRoundIndex(round string, rounds []string) int {
@@ -279,10 +279,10 @@ func getRoundIndex(round string, rounds []string) int {
 // Helper function to get the names of rounds for a single elim tournament, this is a hardcoded list with a limit of 32 matches
 // Preconditions Receives int containing number of matches in this tournament
 // Postconditions: Returns string slice containing round names, or error if it occurs
-func getRoundNames(numMatches int) ([]string, error){
+func getRoundNames(numMatches int) ([]string, error) {
 	// Find the number of rounds, this way we can make sure the name mapping is correct
 	// numRounds = log_2 (numMatches + 1) since there are always n-1 matches for a single elim tournament with n teams
-	numRounds := int(math.Ceil(math.Log2(float64(numMatches+1))))
+	numRounds := int(math.Ceil(math.Log2(float64(numMatches + 1))))
 
 	// Hardcoded slice of round names
 	roundNames := []string{
@@ -333,11 +333,11 @@ func ParseScheduledMatches(result interface{}) (*ScheduledMatch, error) {
 		return nil, fmt.Errorf("unexpected value for 'finished': %v (expected 0 or 1)", finishedRes)
 	}
 	isFinished := finishedRes == 1
-	
+
 	// // If match has finished, return nil for this node
 	// if finishedStr != 0 {
 	// 	return nil, nil
-	// } 
+	// }
 
 	// Get match date
 	matchDateStr, ok := match["date"].(string)
@@ -345,7 +345,7 @@ func ParseScheduledMatches(result interface{}) (*ScheduledMatch, error) {
 		return nil, fmt.Errorf("error mapping match2id interface")
 	}
 	// Match dates are in GMT, need to convert to epoch
-	layout := "2006-01-02 15:04:05" 
+	layout := "2006-01-02 15:04:05"
 	parsedTime, err := time.Parse(layout, matchDateStr)
 	if err != nil {
 		return nil, err
@@ -395,15 +395,15 @@ func ParseScheduledMatches(result interface{}) (*ScheduledMatch, error) {
 		}
 		teams[i] = name
 	}
-	
+
 	return &ScheduledMatch{
-		Team1: teams[0],
-		Team2: teams[1],
+		Team1:     teams[0],
+		Team2:     teams[1],
 		EpochTime: epoch,
-		BestOf: bestOf,
+		BestOf:    bestOf,
 		StreamUrl: twitchUrl,
-		Finished: isFinished,
-	}, nil 
+		Finished:  isFinished,
+	}, nil
 
 }
 
@@ -422,10 +422,10 @@ func ExtractMatchListId(wikitext string) ([]string, string, error) {
 	case "single-elimination":
 		re = regexp.MustCompile(`(?s)\{\{\s*Bracket\s*\|([^}]*)\}\}`) // {{ShowBracket ...}} templates used in swiss tournaments
 	default:
-		return nil, "", fmt.Errorf("unknown tournament format detected")
+		return nil, "", fmt.Errorf("unknown tournament format detected %s", format)
 	}
 
-	// Find regex matches 
+	// Find regex matches
 	matches := re.FindAllStringSubmatch(wikitext, -1)
 	for _, match := range matches {
 		paramsText := match[1]
@@ -436,12 +436,12 @@ func ExtractMatchListId(wikitext string) ([]string, string, error) {
 			part = strings.TrimSpace(part)
 			if strings.HasPrefix(part, "id=") {
 				id := strings.TrimSpace(strings.TrimPrefix(part, "id="))
-				
+
 				// Remove trailing html comments (some times occurs in single elim data)
 				reComment := regexp.MustCompile(`<!--.*?-->`)
 				id = reComment.ReplaceAllString(id, "")
 				id = strings.TrimSpace(id)
-				
+
 				if id != "" {
 					ids = append(ids, id)
 				}
@@ -469,7 +469,7 @@ func DetectTournamentFormat(wikitext string) string {
 		formatSection := results[1] // format is listed on the second line of the format section in wikitext
 		switch {
 		case strings.Contains(strings.ToLower(formatSection), "swiss") && strings.Contains(strings.ToLower(formatSection), "single-elimination"):
-		// This case occurs when both styles are on a singular page. This doesnt occur during the major and is just here for testing
+			// This case occurs when both styles are on a singular page. This doesnt occur during the major and is just here for testing
 			return "single-elimination"
 		case strings.Contains(strings.ToLower(formatSection), "swiss"):
 			return "swiss"

--- a/api/external/parser.go
+++ b/api/external/parser.go
@@ -421,6 +421,8 @@ func ExtractMatchListId(wikitext string) ([]string, string, error) {
 		re = regexp.MustCompile(`(?s)\{\{\s*Matchlist\s*\|([^}]*)\}\}`) // {{Matchlist ...}} templates used in swiss tournaments
 	case "single-elimination":
 		re = regexp.MustCompile(`(?s)\{\{\s*Bracket\s*\|([^}]*)\}\}`) // {{ShowBracket ...}} templates used in swiss tournaments
+	case "double-elimination":
+		re = regexp.MustCompile(`(?s)\{\{\s*Bracket\s*\|([^}]*)\}\}`) // {{ShowBracket ...}} templates used in swiss tournaments
 	default:
 		return nil, "", fmt.Errorf("unknown tournament format detected %s", format)
 	}
@@ -475,6 +477,8 @@ func DetectTournamentFormat(wikitext string) string {
 			return "swiss"
 		case strings.Contains(strings.ToLower(formatSection), "single-elimination"):
 			return "single-elimination"
+		case strings.Contains(strings.ToLower(formatSection), "double-elimination"):
+			return "double-elimination"
 		default:
 			return "unknown"
 		}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@ FROM golang:1.24-alpine
 WORKDIR /app
 
 # Copy go mod and source
-COPY go.mod ./
-COPY . ./
+COPY ../go.mod ./
+COPY .. ./
 
 # Build the app
 RUN go build -o pickems

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: pickems-bot
     build:
       context: ..
-      dockerfile: Dockerfile
+      dockerfile: docker/Dockerfile
     env_file:
       - ../.env
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   app:
     container_name: pickems-bot
     build:
-      context: .
+      context: ..
       dockerfile: Dockerfile
     env_file:
-      - .env
+      - ../.env
     restart: unless-stopped

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	api "pickems-bot/api/api"
 	bot "pickems-bot/bot"
@@ -62,7 +63,12 @@ func main() {
 			panic(err)
 		}
 	}()
-	err = apiInstance.PopulateMatches()
+
+	isUpcomingOnly, err := convertStrToBool(upcomingOnly)
+	if err != nil {
+		log.Fatalf("failed to convert upcoming only: %v. Value should be true or false", err)
+	}
+	err = apiInstance.PopulateMatches(isUpcomingOnly)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -83,4 +89,19 @@ func main() {
 	if err != nil {
 		log.Fatal(fmt.Errorf("an unrecoverable error occured whilst running the bot: %w", err))
 	}
+}
+
+// Helper function to convert a string of true or false into a boolean for comparisons
+// Preconditions: Receives string containing either true or false (case insensitive)
+// Postconditions: Returns boolean value or an error if the string is not true or false
+func convertStrToBool(str string) (bool, error) {
+	str = strings.TrimSpace(str)
+	str = strings.ToLower(str)
+
+	if str == "true" {
+		return true, nil
+	} else if str == "false" {
+		return false, nil
+	}
+	return false, fmt.Errorf("invalid boolean string")
 }

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	page := os.Getenv("PAGE")
 	params := os.Getenv("PARAMS")
 	test := os.Getenv("TEST")
+	upcomingOnly := os.Getenv("UPCOMING_ONLY")
 
 	// Default values if environmental variables not found
 	if tournamentName == "" {
@@ -45,6 +46,10 @@ func main() {
 	if test == "" {
 		test = "false"
 	}
+	if upcomingOnly == "" {
+		upcomingOnly = "false"
+	}
+
 	// Init API
 	fullPage := fmt.Sprintf("%s/%s", page, round)
 	apiInstance, err := api.NewAPI(tournamentName, os.Getenv("MONGO_PROD_URI"), fullPage, params, round)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,7 +4,7 @@ set -e  # Exit on error
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 echo "Deploy started at $(date)"
-cd /home/latte/PickemsBot
+cd /home/latte/PickemsBot/docker
 
 git pull origin main
 git config --global --add safe.directory /home/latte/PickemsBot


### PR DESCRIPTION
This PR adds support for the `upcomingOnly` configuration. This mode allows the bot to run without getting match results. It removes the ability to set predictions in this mode but allows for getting upcoming matches of unsupported formats such as double elim