### PR TITLE
Added leaderboard message pre-operation

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -168,6 +168,7 @@ func (b *Bot) checkPredictions(discord *discordgo.Session, message *discordgo.Me
 // Preconditions: Recieves pointer to the discordgo session and discordgo message
 // Postconditions: Generates leaderboard and posts leaderboard to same channel command was run
 func (b *Bot) leaderboard(discord *discordgo.Session, message *discordgo.MessageCreate) {
+	discord.ChannelMessageSend(message.ChannelID, "Getting the leaderboard...")
 	res, err := b.APIPtr.GetLeaderboard()
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Fixes #27 by adding a message pre-operation so that users are aware that the bot is performing an operation during long leaderboard calls.

Should not require any new test coverage.