### PR TITLE
feat: add configure script and split tournament config from secrets

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,8 @@
+# Tournament configuration. Generated/updated by `go run ./scripts/configure`.
+
+tournament_name = "Blast_Austin_Major_2025"
+page           = "BLAST/Major/2025/Austin/Stage_1"
+round          = "Stage_1"
+params         = ""
+upcoming_only  = false
+test           = false

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,33 @@
+/* config.go
+ * Loads tournament configuration from a TOML file. Secrets stay in env vars.
+ */
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config holds the tournament configuration loaded from config.toml.
+type Config struct {
+	TournamentName string `toml:"tournament_name"`
+	Page           string `toml:"page"`
+	Round          string `toml:"round"`
+	Params         string `toml:"params"`
+	UpcomingOnly   bool   `toml:"upcoming_only"`
+	Test           bool   `toml:"test"`
+}
+
+// Load reads and validates a config.toml file at path.
+func Load(path string) (Config, error) {
+	var c Config
+	if _, err := toml.DecodeFile(path, &c); err != nil {
+		return Config{}, fmt.Errorf("decode %s: %w", path, err)
+	}
+	if c.TournamentName == "" || c.Page == "" || c.Round == "" {
+		return Config{}, fmt.Errorf("tournament_name, page, and round are required in %s", path)
+	}
+	return c, nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,99 @@
+/* config_test.go
+ * Tests for the config loader.
+ */
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeTemp(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("writeTemp: %v", err)
+	}
+	return path
+}
+
+func TestLoad_AllFields(t *testing.T) {
+	path := writeTemp(t, `
+tournament_name = "MyEvent_2026"
+page = "Foo/2026/Bar/Stage_1"
+round = "Stage_1"
+params = "&section=24"
+upcoming_only = true
+test = true
+`)
+
+	cfg, err := Load(path)
+	assert.NoError(t, err)
+	assert.Equal(t, "MyEvent_2026", cfg.TournamentName)
+	assert.Equal(t, "Foo/2026/Bar/Stage_1", cfg.Page)
+	assert.Equal(t, "Stage_1", cfg.Round)
+	assert.Equal(t, "&section=24", cfg.Params)
+	assert.True(t, cfg.UpcomingOnly)
+	assert.True(t, cfg.Test)
+}
+
+func TestLoad_DefaultBoolsAndOptionalParams(t *testing.T) {
+	path := writeTemp(t, `
+tournament_name = "X"
+page = "Y/Z"
+round = "Z"
+`)
+
+	cfg, err := Load(path)
+	assert.NoError(t, err)
+	assert.Equal(t, "", cfg.Params)
+	assert.False(t, cfg.UpcomingOnly)
+	assert.False(t, cfg.Test)
+}
+
+func TestLoad_MissingTournamentName(t *testing.T) {
+	path := writeTemp(t, `
+page = "Y/Z"
+round = "Z"
+`)
+
+	_, err := Load(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestLoad_MissingPage(t *testing.T) {
+	path := writeTemp(t, `
+tournament_name = "X"
+round = "Z"
+`)
+
+	_, err := Load(path)
+	assert.Error(t, err)
+}
+
+func TestLoad_MissingRound(t *testing.T) {
+	path := writeTemp(t, `
+tournament_name = "X"
+page = "Y/Z"
+`)
+
+	_, err := Load(path)
+	assert.Error(t, err)
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := Load("/nonexistent/path/config.toml")
+	assert.Error(t, err)
+}
+
+func TestLoad_InvalidTOML(t *testing.T) {
+	path := writeTemp(t, "this is not = valid toml [[[")
+	_, err := Load(path)
+	assert.Error(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.3
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/go-andiamo/splitter v1.2.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.go
+++ b/main.go
@@ -2,9 +2,9 @@
 
 /* main.go
  * The "main" method for running the bot. For details about the bot see `readme.md`
- * Usage: go run main.go -format="<format>" -url="<url>"
+ * Tournament settings live in config.toml (see `go run ./scripts/configure`).
+ * Secrets (Discord tokens, Mongo URI, Liquipedia API key) live in .env.
  * Authors: Zachary Bower
- * Last modified: 29/05/2025
  */
 
 package main
@@ -14,49 +14,26 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"pickems-bot/web"
 
 	api "pickems-bot/api/api"
 	bot "pickems-bot/bot"
+	"pickems-bot/config"
+	"pickems-bot/web"
 
 	"github.com/joho/godotenv"
 )
 
 func main() {
-	err := godotenv.Load()
-	if err != nil {
+	if err := godotenv.Load(); err != nil {
 		log.Fatal("Error loading .env file")
 	}
 
-	// Get tournament name, round, page, params and test from .env file
-	tournamentName := os.Getenv("TOURNAMENT_NAME")
-	round := os.Getenv("ROUND")
-	page := os.Getenv("PAGE")
-	params := os.Getenv("PARAMS")
-	test := os.Getenv("TEST")
-	upcomingOnly := os.Getenv("UPCOMING_ONLY")
-
-	// Default values if environmental variables not found
-	if tournamentName == "" {
-		tournamentName = "Blast_Austin_Major_2025"
-	}
-	if round == "" {
-		round = "Stage_1"
-	}
-	if page == "" {
-		page = "BLAST/Major/2025/Austin"
-	}
-	if test == "" {
-		test = "false"
-	}
-	if upcomingOnly == "" {
-		upcomingOnly = "false"
+	cfg, err := config.Load("config.toml")
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
 	}
 
-	// Init API
-	fullPage := fmt.Sprintf("%s/%s", page, round)
-	apiInstance, err := api.NewAPI(tournamentName, os.Getenv("MONGO_PROD_URI"), fullPage, params, round)
-
+	apiInstance, err := api.NewAPI(cfg.TournamentName, os.Getenv("MONGO_PROD_URI"), cfg.Page, cfg.Params, cfg.Round)
 	if err != nil {
 		log.Fatalf("failed to initialize API: %v", err)
 	}
@@ -66,40 +43,31 @@ func main() {
 		}
 	}()
 
-	isUpcomingOnly, err := convertStrToBool(upcomingOnly)
-	if err != nil {
-		log.Fatalf("failed to convert upcoming only: %v. Value should be true or false", err)
-	}
-	err = apiInstance.PopulateMatches(isUpcomingOnly)
-	if err != nil {
+	if err := apiInstance.PopulateMatches(cfg.UpcomingOnly); err != nil {
 		log.Fatal(err)
 	}
-	err = apiInstance.GenerateLeaderboard()
-	if err != nil {
+	if err := apiInstance.GenerateLeaderboard(); err != nil {
 		log.Fatal(err)
 	}
 
-	//Init bot
 	var discordToken string
-	if test == "false" { //Load production bot token
-		discordToken = os.Getenv("DISCORD_PROD_TOKEN")
-	} else if test == "true" {
+	if cfg.Test {
 		discordToken = os.Getenv("DISCORD_BETA_TOKEN")
 	} else {
-		fmt.Println("Invalid \"test\" value. Should be true or false")
+		discordToken = os.Getenv("DISCORD_PROD_TOKEN")
 	}
 	botInstance, err := bot.NewBot(discordToken, apiInstance)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	// Start web server for webhooks
 	go func() {
 		if err := web.Start(web.Config{Addr: ":8080", API: apiInstance}); err != nil {
 			log.Fatalf("failed to start web server: %v", err)
 		}
 	}()
 
-	// Run bot
-	err = botInstance.Run()
-	if err != nil {
+	if err := botInstance.Run(); err != nil {
 		log.Fatal(fmt.Errorf("an unrecoverable error occured whilst running the bot: %w", err))
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -15,12 +15,49 @@ The following are discord messages that the bot will respond to. These can be in
 `$upcoming`: shows todays live and upcoming matches
 
 ## Usage
-TODO: Update commands for V3.
 
-Run the bot with `go run main.go -format="<format>" -url="<url>` \
-Alternatively use the docker image, this will provide a persistant bot so if you close the terminal the bot doesn't go offline. \
-Build the docker image with `docker build -t pickems-bot .` \
-Run the container with `docker run pickems-bot`  
+### Configuration
+
+The bot reads from two files:
+
+- `.env` — secrets only (Discord tokens, Mongo URI, Liquipedia API key). Not tracked in git.
+- `config.toml` — tournament settings (page, round, etc.). Tracked in git so the active tournament is committed alongside the code.
+
+Required `.env` keys:
+
+```
+DISCORD_PROD_TOKEN=...
+DISCORD_BETA_TOKEN=...
+MONGO_PROD_URI=...
+LIQUIDPEDIADB_API_KEY=...
+```
+
+### Generating config.toml for a new tournament
+
+Use the configure script — point it at any Liquipedia tournament page and it'll fetch the wikitext, find the available stages, and write `config.toml`:
+
+```bash
+go run ./scripts/configure -url https://liquipedia.net/counterstrike/Intel_Extreme_Masters/2026/Cologne
+```
+
+If the tournament has multiple stages, you'll get an interactive picker. Skip the prompt with `-stage`:
+
+```bash
+go run ./scripts/configure -url https://liquipedia.net/counterstrike/PGL/2026/Bucharest -stage Europe
+```
+
+### Running
+
+```bash
+go run .
+```
+
+Or via Docker (persistent — survives shell exit):
+
+```bash
+docker build -t pickems-bot .
+docker run --env-file .env -v "$PWD/config.toml:/app/config.toml:ro" pickems-bot
+```
 
 ## Version History
 ### v1.0

--- a/scripts/configure/configure.go
+++ b/scripts/configure/configure.go
@@ -1,0 +1,175 @@
+/* configure.go
+ * Pure helpers used by the configure script. Kept separate from main.go
+ * so they're reachable from tests (main.go uses //go:build !test).
+ */
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"pickems-bot/api/external"
+)
+
+const liquipediaBase = "https://liquipedia.net/counterstrike/"
+
+type tournamentConfig struct {
+	Name         string
+	Page         string
+	Round        string
+	Params       string
+	UpcomingOnly bool
+	Test         bool
+}
+
+func fetchWikitext(path string) (string, error) {
+	wikitext, err := external.GetWikitext(liquipediaBase + path + "?action=raw")
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(wikitext) == "" {
+		return "", fmt.Errorf("empty response (page may not exist)")
+	}
+	return wikitext, nil
+}
+
+func pagePathFromURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if !strings.Contains(u.Host, "liquipedia.net") {
+		return "", fmt.Errorf("expected a liquipedia.net URL")
+	}
+	path := strings.TrimPrefix(u.Path, "/counterstrike/")
+	path = strings.Trim(path, "/")
+	if path == "" || path == strings.Trim(u.Path, "/") {
+		return "", fmt.Errorf("URL must point to a /counterstrike/ page")
+	}
+	return path, nil
+}
+
+var nameRe = regexp.MustCompile(`\|\s*name\s*=\s*([^|\n]+)`)
+
+func extractTournamentName(wikitext string) string {
+	m := nameRe.FindStringSubmatch(wikitext)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+var relativeLinkRe = regexp.MustCompile(`\[\[/([^|\]/]+)`)
+
+// extractStages returns top-level sub-stage names (e.g. Stage_1, Playoffs, Europe)
+// found in the page wikitext. Catches multiple reference forms: wikilinks
+// ([[Base/Stage 1|...]]), relative wikilinks ([[/Stage 1|...]]), section
+// transclusions ({{#section:Base/Stage 1|...}}), and bare template params
+// (|tournament4=Base/Playoffs). Nested paths collapse to their first segment.
+func extractStages(wikitext, basePath string) []string {
+	baseSpaces := strings.ReplaceAll(basePath, "_", " ")
+	seen := map[string]struct{}{}
+
+	add := func(sub string) {
+		sub = strings.TrimSpace(sub)
+		if i := strings.Index(sub, "/"); i >= 0 {
+			sub = sub[:i]
+		}
+		if sub == "" || strings.HasPrefix(sub, "#") {
+			return
+		}
+		seen[strings.ReplaceAll(sub, " ", "_")] = struct{}{}
+	}
+
+	for _, m := range relativeLinkRe.FindAllStringSubmatch(wikitext, -1) {
+		add(m[1])
+	}
+
+	pat := fmt.Sprintf(`(?:%s|%s)/([A-Za-z0-9 _\-]+)`,
+		regexp.QuoteMeta(basePath), regexp.QuoteMeta(baseSpaces))
+	absRe := regexp.MustCompile(pat)
+	for _, m := range absRe.FindAllStringSubmatch(wikitext, -1) {
+		add(m[1])
+	}
+
+	stages := make([]string, 0, len(seen))
+	for s := range seen {
+		stages = append(stages, s)
+	}
+	sort.Strings(stages)
+	return stages
+}
+
+func resolveStage(flagValue string, stages []string, basePath string, in io.Reader, out io.Writer) (round, page string, err error) {
+	switch {
+	case flagValue != "":
+		return flagValue, basePath + "/" + flagValue, nil
+	case len(stages) == 0:
+		fmt.Fprintln(out, "No sub-stages found — using base page as the round.")
+		return "Main", basePath, nil
+	case len(stages) == 1:
+		fmt.Fprintf(out, "Single stage detected: %s\n", stages[0])
+		return stages[0], basePath + "/" + stages[0], nil
+	default:
+		picked, err := pickStage(stages, in, out)
+		if err != nil {
+			return "", "", err
+		}
+		return picked, basePath + "/" + picked, nil
+	}
+}
+
+func pickStage(stages []string, in io.Reader, out io.Writer) (string, error) {
+	fmt.Fprintln(out, "\nAvailable stages:")
+	for i, s := range stages {
+		fmt.Fprintf(out, "  [%d] %s\n", i+1, s)
+	}
+	fmt.Fprint(out, "Pick a stage [1]: ")
+
+	reader := bufio.NewReader(in)
+	line, _ := reader.ReadString('\n')
+	line = strings.TrimSpace(line)
+
+	idx := 1
+	if line != "" {
+		if _, err := fmt.Sscanf(line, "%d", &idx); err != nil {
+			return "", fmt.Errorf("invalid input: %w", err)
+		}
+	}
+	if idx < 1 || idx > len(stages) {
+		return "", fmt.Errorf("selection out of range")
+	}
+	return stages[idx-1], nil
+}
+
+var nonAlnum = regexp.MustCompile(`[^A-Za-z0-9]+`)
+
+// mongoSafe normalises a free-form name into a Mongo-friendly database name.
+func mongoSafe(s string) string {
+	s = nonAlnum.ReplaceAllString(strings.TrimSpace(s), "_")
+	return strings.Trim(s, "_")
+}
+
+func writeConfig(path string, c tournamentConfig) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fmt.Fprintln(f, "# Tournament configuration. Generated/updated by `go run ./scripts/configure`.")
+	fmt.Fprintln(f)
+	fmt.Fprintf(f, "tournament_name = %q\n", c.Name)
+	fmt.Fprintf(f, "page           = %q\n", c.Page)
+	fmt.Fprintf(f, "round          = %q\n", c.Round)
+	fmt.Fprintf(f, "params         = %q\n", c.Params)
+	fmt.Fprintf(f, "upcoming_only  = %t\n", c.UpcomingOnly)
+	fmt.Fprintf(f, "test           = %t\n", c.Test)
+	return nil
+}

--- a/scripts/configure/main.go
+++ b/scripts/configure/main.go
@@ -1,0 +1,76 @@
+//go:build !test
+
+/* scripts/configure
+ * Generates config.toml from a Liquipedia tournament URL by parsing the
+ * page wikitext for the tournament name and available sub-stages.
+ *
+ * Usage:
+ *   go run ./scripts/configure -url https://liquipedia.net/counterstrike/Foo/2026/Bar
+ *   go run ./scripts/configure -url <url> -stage Stage_1
+ *   go run ./scripts/configure -url <url> -out custom.toml
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+func main() {
+	tourneyURL := flag.String("url", "", "Liquipedia tournament URL (required)")
+	stage := flag.String("stage", "", "Stage name to use (skips interactive picker)")
+	out := flag.String("out", "config.toml", "Output config file path")
+	flag.Parse()
+
+	if *tourneyURL == "" {
+		log.Fatal("missing required flag: -url")
+	}
+
+	basePath, err := pagePathFromURL(*tourneyURL)
+	if err != nil {
+		log.Fatalf("invalid URL: %v", err)
+	}
+
+	fmt.Printf("Fetching %s...\n", basePath)
+	wikitext, err := fetchWikitext(basePath)
+	if err != nil {
+		log.Fatalf("fetch wikitext: %v", err)
+	}
+
+	tournamentName := extractTournamentName(wikitext)
+	if tournamentName == "" {
+		log.Fatal("could not extract tournament name from wikitext (|name= field missing)")
+	}
+	fmt.Printf("Tournament: %s\n", tournamentName)
+
+	stages := extractStages(wikitext, basePath)
+
+	chosenStage, chosenPage, err := resolveStage(*stage, stages, basePath, os.Stdin, os.Stdout)
+	if err != nil {
+		log.Fatalf("resolve stage: %v", err)
+	}
+
+	if chosenPage != basePath {
+		fmt.Printf("Validating %s...\n", chosenPage)
+		if _, err := fetchWikitext(chosenPage); err != nil {
+			log.Fatalf("chosen stage page does not load: %v", err)
+		}
+	}
+
+	cfg := tournamentConfig{
+		Name:  mongoSafe(tournamentName),
+		Page:  chosenPage,
+		Round: chosenStage,
+	}
+
+	if err := writeConfig(*out, cfg); err != nil {
+		log.Fatalf("write config: %v", err)
+	}
+	fmt.Printf("\nWrote %s:\n", *out)
+	fmt.Printf("  tournament_name = %q\n", cfg.Name)
+	fmt.Printf("  page            = %q\n", cfg.Page)
+	fmt.Printf("  round           = %q\n", cfg.Round)
+}

--- a/scripts/configure/main_test.go
+++ b/scripts/configure/main_test.go
@@ -1,0 +1,245 @@
+/* main_test.go
+ * Tests for the pure helper functions in the configure script.
+ */
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// region pagePathFromURL
+
+func TestPagePathFromURL_Simple(t *testing.T) {
+	p, err := pagePathFromURL("https://liquipedia.net/counterstrike/PGL/2026/Bucharest")
+	assert.NoError(t, err)
+	assert.Equal(t, "PGL/2026/Bucharest", p)
+}
+
+func TestPagePathFromURL_TrailingSlash(t *testing.T) {
+	p, err := pagePathFromURL("https://liquipedia.net/counterstrike/PGL/2026/Bucharest/")
+	assert.NoError(t, err)
+	assert.Equal(t, "PGL/2026/Bucharest", p)
+}
+
+func TestPagePathFromURL_StripsQueryAndFragment(t *testing.T) {
+	p, err := pagePathFromURL("https://liquipedia.net/counterstrike/PGL/2026/Bucharest?foo=bar#schedule")
+	assert.NoError(t, err)
+	assert.Equal(t, "PGL/2026/Bucharest", p)
+}
+
+func TestPagePathFromURL_WrongHost(t *testing.T) {
+	_, err := pagePathFromURL("https://example.com/counterstrike/PGL/2026/Bucharest")
+	assert.Error(t, err)
+}
+
+func TestPagePathFromURL_NotCounterstrike(t *testing.T) {
+	_, err := pagePathFromURL("https://liquipedia.net/dota2/Some/Page")
+	assert.Error(t, err)
+}
+
+func TestPagePathFromURL_Empty(t *testing.T) {
+	_, err := pagePathFromURL("https://liquipedia.net/counterstrike/")
+	assert.Error(t, err)
+}
+
+func TestPagePathFromURL_Malformed(t *testing.T) {
+	_, err := pagePathFromURL("://not a url")
+	assert.Error(t, err)
+}
+
+// endregion
+
+// region extractTournamentName
+
+func TestExtractTournamentName_BasicInfobox(t *testing.T) {
+	wikitext := `{{Infobox league
+|name=PGL Bucharest 2026
+|series=PGL Major
+|liquipediatier=A-Tier
+}}`
+	assert.Equal(t, "PGL Bucharest 2026", extractTournamentName(wikitext))
+}
+
+func TestExtractTournamentName_LeadingWhitespace(t *testing.T) {
+	wikitext := `{{Infobox league
+   |  name  =  Intel Extreme Masters Cologne Major 2026
+}}`
+	assert.Equal(t, "Intel Extreme Masters Cologne Major 2026", extractTournamentName(wikitext))
+}
+
+func TestExtractTournamentName_NotFound(t *testing.T) {
+	assert.Equal(t, "", extractTournamentName("no infobox here"))
+}
+
+// endregion
+
+// region extractStages
+
+func TestExtractStages_AbsoluteUnderscoreLinks(t *testing.T) {
+	wikitext := `Some content [[Foo/2026/Bar/Stage_1|results]] more [[Foo/2026/Bar/Stage_2|here]]`
+	stages := extractStages(wikitext, "Foo/2026/Bar")
+	assert.Equal(t, []string{"Stage_1", "Stage_2"}, stages)
+}
+
+func TestExtractStages_AbsoluteSpaceLinks(t *testing.T) {
+	wikitext := `[[Intel Extreme Masters/2026/Cologne/Stage 1|click here]]
+[[Intel Extreme Masters/2026/Cologne/Stage 2|click here]]`
+	stages := extractStages(wikitext, "Intel_Extreme_Masters/2026/Cologne")
+	assert.Equal(t, []string{"Stage_1", "Stage_2"}, stages)
+}
+
+func TestExtractStages_RelativeLinks(t *testing.T) {
+	wikitext := `[[/Qualifier|Closed Qualifier]]`
+	stages := extractStages(wikitext, "BLAST/Bounty/2026/Summer")
+	assert.Equal(t, []string{"Qualifier"}, stages)
+}
+
+func TestExtractStages_BareTemplateParams(t *testing.T) {
+	// |tournament4=Foo/2026/Bar/Playoffs is a common template usage that isn't a wikilink
+	wikitext := `|tournament1=#Stage 1|tournament4=Intel Extreme Masters/2026/Cologne/Playoffs`
+	stages := extractStages(wikitext, "Intel_Extreme_Masters/2026/Cologne")
+	assert.Equal(t, []string{"Playoffs"}, stages)
+}
+
+func TestExtractStages_SectionTransclusion(t *testing.T) {
+	wikitext := `{{#section:Foo/2026/Bar/Stage 1|Results}}`
+	stages := extractStages(wikitext, "Foo/2026/Bar")
+	assert.Equal(t, []string{"Stage_1"}, stages)
+}
+
+func TestExtractStages_NestedCollapseToFirstSegment(t *testing.T) {
+	wikitext := `[[Intel Extreme Masters/2026/Rio/Qualifier/Global|...]]
+[[Intel Extreme Masters/2026/Rio/Qualifier/Americas|...]]`
+	stages := extractStages(wikitext, "Intel_Extreme_Masters/2026/Rio")
+	assert.Equal(t, []string{"Qualifier"}, stages)
+}
+
+func TestExtractStages_Dedupe(t *testing.T) {
+	wikitext := `[[Foo/Bar/Stage_1|x]] [[Foo/Bar/Stage_1|y]] [[/Stage 1|z]]`
+	stages := extractStages(wikitext, "Foo/Bar")
+	assert.Equal(t, []string{"Stage_1"}, stages)
+}
+
+func TestExtractStages_None(t *testing.T) {
+	stages := extractStages("nothing relevant here", "Foo/Bar")
+	assert.Empty(t, stages)
+}
+
+func TestExtractStages_IgnoresAnchors(t *testing.T) {
+	wikitext := `|tournament1=#Stage 1`
+	stages := extractStages(wikitext, "Foo/Bar")
+	assert.Empty(t, stages)
+}
+
+// endregion
+
+// region resolveStage
+
+func TestResolveStage_FlagOverride(t *testing.T) {
+	round, page, err := resolveStage("Stage_2", []string{"Stage_1"}, "Foo/Bar", strings.NewReader(""), &bytes.Buffer{})
+	assert.NoError(t, err)
+	assert.Equal(t, "Stage_2", round)
+	assert.Equal(t, "Foo/Bar/Stage_2", page)
+}
+
+func TestResolveStage_NoStages(t *testing.T) {
+	round, page, err := resolveStage("", []string{}, "Foo/Bar", strings.NewReader(""), &bytes.Buffer{})
+	assert.NoError(t, err)
+	assert.Equal(t, "Main", round)
+	assert.Equal(t, "Foo/Bar", page)
+}
+
+func TestResolveStage_SingleStage(t *testing.T) {
+	round, page, err := resolveStage("", []string{"Qualifier"}, "Foo/Bar", strings.NewReader(""), &bytes.Buffer{})
+	assert.NoError(t, err)
+	assert.Equal(t, "Qualifier", round)
+	assert.Equal(t, "Foo/Bar/Qualifier", page)
+}
+
+func TestResolveStage_MultiStagePicked(t *testing.T) {
+	round, page, err := resolveStage("", []string{"Stage_1", "Stage_2", "Playoffs"}, "Foo/Bar", strings.NewReader("3\n"), &bytes.Buffer{})
+	assert.NoError(t, err)
+	assert.Equal(t, "Playoffs", round)
+	assert.Equal(t, "Foo/Bar/Playoffs", page)
+}
+
+// endregion
+
+// region pickStage
+
+func TestPickStage_DefaultsToFirst(t *testing.T) {
+	got, err := pickStage([]string{"a", "b"}, strings.NewReader("\n"), &bytes.Buffer{})
+	assert.NoError(t, err)
+	assert.Equal(t, "a", got)
+}
+
+func TestPickStage_ExplicitChoice(t *testing.T) {
+	got, err := pickStage([]string{"a", "b", "c"}, strings.NewReader("2\n"), &bytes.Buffer{})
+	assert.NoError(t, err)
+	assert.Equal(t, "b", got)
+}
+
+func TestPickStage_OutOfRange(t *testing.T) {
+	_, err := pickStage([]string{"a", "b"}, strings.NewReader("5\n"), &bytes.Buffer{})
+	assert.Error(t, err)
+}
+
+func TestPickStage_InvalidInput(t *testing.T) {
+	_, err := pickStage([]string{"a", "b"}, strings.NewReader("not-a-number\n"), &bytes.Buffer{})
+	assert.Error(t, err)
+}
+
+// endregion
+
+// region mongoSafe
+
+func TestMongoSafe(t *testing.T) {
+	assert.Equal(t, "Intel_Extreme_Masters_Cologne_Major_2026", mongoSafe("Intel Extreme Masters Cologne Major 2026"))
+	assert.Equal(t, "BLAST_tv_Austin_Major_2025", mongoSafe("BLAST.tv Austin Major 2025"))
+	assert.Equal(t, "PGL_Bucharest_2026", mongoSafe("  PGL Bucharest 2026  "))
+	assert.Equal(t, "X", mongoSafe("___X___"))
+}
+
+// endregion
+
+// region writeConfig
+
+func TestWriteConfig_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.toml")
+
+	cfg := tournamentConfig{
+		Name:         "Foo_2026",
+		Page:         "Foo/2026/Bar/Stage_1",
+		Round:        "Stage_1",
+		Params:       "",
+		UpcomingOnly: false,
+		Test:         false,
+	}
+	err := writeConfig(path, cfg)
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	out := string(data)
+	assert.Contains(t, out, `tournament_name = "Foo_2026"`)
+	assert.Contains(t, out, `page           = "Foo/2026/Bar/Stage_1"`)
+	assert.Contains(t, out, `round          = "Stage_1"`)
+	assert.Contains(t, out, `upcoming_only  = false`)
+	assert.True(t, strings.HasPrefix(out, "#"), "expected header comment")
+}
+
+func TestWriteConfig_BadPath(t *testing.T) {
+	err := writeConfig("/nonexistent/dir/out.toml", tournamentConfig{})
+	assert.Error(t, err)
+}
+
+// endregion

--- a/web/liquipedia.go
+++ b/web/liquipedia.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 )
 
@@ -40,14 +39,11 @@ func (s *Server) LiquipediaWebhookHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	expectedWiki := "counterstrike"
-	basePage := os.Getenv("PAGE")
-
-	if event.Wiki != expectedWiki {
+	if event.Wiki != "counterstrike" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	if !isRelevantTournamentPage(event.Page, basePage) {
+	if !isRelevantTournamentPage(event.Page, s.api.Store.GetPage()) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/web/liquipedia_test.go
+++ b/web/liquipedia_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	apiPkg "pickems-bot/api/api"
@@ -99,16 +98,12 @@ func TestLiquipediaWebhookHandler_WrongWiki(t *testing.T) {
 }
 
 func TestLiquipediaWebhookHandler_IrrelevantPage(t *testing.T) {
-	// Set the PAGE environment variable
-	originalPage := os.Getenv("PAGE")
-	os.Setenv("PAGE", "BLAST/Premier/2025/World_Final")
-	defer os.Setenv("PAGE", originalPage)
-
-	server := &Server{api: nil}
+	mockStore := apiPkg.NewMockStore("swiss", "test_round")
+	server := &Server{api: &apiPkg.API{Store: mockStore}}
 
 	event := LiquipediaEvent{
 		Wiki:  "counterstrike",
-		Page:  "ESL/Pro_League/Season_20", // Different tournament
+		Page:  "ESL/Pro_League/Season_20", // Different tournament from MockStore page
 		Event: "update",
 	}
 	body, _ := json.Marshal(event)
@@ -129,12 +124,7 @@ func TestLiquipediaWebhookHandler_IrrelevantPage(t *testing.T) {
 // TestLiquipediaWebhookHandler_RelevantEvent_ReturnsOK tests that relevant events return 200 OK
 // This test uses a mock API to test the full flow
 func TestLiquipediaWebhookHandler_RelevantEvent_ReturnsOK(t *testing.T) {
-	// Set the PAGE environment variable
-	originalPage := os.Getenv("PAGE")
-	os.Setenv("PAGE", "BLAST/Premier/2025/World_Final")
-	defer os.Setenv("PAGE", originalPage)
-
-	// Create server with mock API from api package
+	// Create server with mock API from api package (mock GetPage returns "Test/Tournament/2025")
 	mockStore := apiPkg.NewMockStore("swiss", "test_round")
 	mockStore.SetSwissResults(map[string]string{"Team A": "3-0"})
 	mockAPI := &apiPkg.API{Store: mockStore}
@@ -143,7 +133,7 @@ func TestLiquipediaWebhookHandler_RelevantEvent_ReturnsOK(t *testing.T) {
 
 	event := LiquipediaEvent{
 		Wiki:  "counterstrike",
-		Page:  "BLAST/Premier/2025/World_Final",
+		Page:  "Test/Tournament/2025",
 		Event: "update",
 	}
 	body, _ := json.Marshal(event)
@@ -159,12 +149,7 @@ func TestLiquipediaWebhookHandler_RelevantEvent_ReturnsOK(t *testing.T) {
 
 // TestLiquipediaWebhookHandler_SubPageMatch_ReturnsOK tests sub-page matching
 func TestLiquipediaWebhookHandler_SubPageMatch_ReturnsOK(t *testing.T) {
-	// Set the PAGE environment variable
-	originalPage := os.Getenv("PAGE")
-	os.Setenv("PAGE", "BLAST/Premier/2025/World_Final")
-	defer os.Setenv("PAGE", originalPage)
-
-	// Create server with mock API
+	// Create server with mock API (mock GetPage returns "Test/Tournament/2025")
 	mockStore := apiPkg.NewMockStore("swiss", "test_round")
 	mockStore.SetSwissResults(map[string]string{"Team A": "3-0"})
 	mockAPI := &apiPkg.API{Store: mockStore}
@@ -173,7 +158,7 @@ func TestLiquipediaWebhookHandler_SubPageMatch_ReturnsOK(t *testing.T) {
 
 	event := LiquipediaEvent{
 		Wiki:  "counterstrike",
-		Page:  "BLAST/Premier/2025/World_Final/Opening_Stage", // Sub-page
+		Page:  "Test/Tournament/2025/Opening_Stage", // Sub-page
 		Event: "update",
 	}
 	body, _ := json.Marshal(event)


### PR DESCRIPTION
Closes #31.

## Summary
- Adds `scripts/configure` — a Go script that takes a Liquipedia tournament URL, fetches the page wikitext, extracts the tournament name and available stages (handling absolute wikilinks, relative wikilinks, section transclusions, and bare template params), and writes `config.toml`. Multi-stage tournaments get an interactive picker; `-stage <name>` skips it.
- Splits configuration: tournament settings (`tournament_name`, `page`, `round`, `params`, `upcoming_only`, `test`) move to `config.toml` (tracked); `.env` keeps only secrets (Discord tokens, Mongo URI, Liquipedia API key).
- Drops the `page = page + "/" + round` join in `main.go` — `config.toml` stores the full path, fixing the trailing-slash bug for tournaments without sub-stages.
- `web/liquipedia.go` reads the configured page from `s.api.Store.GetPage()` instead of `os.Getenv("PAGE")`.

## Notes
- Verified end-to-end against IEM Cologne, IEM Rio, PGL Bucharest, BLAST Bounty Summer, and BLAST Austin Major URLs.
- Tournament names are now derived directly from Liquipedia (e.g. `BLAST_tv_Austin_Major_2025` instead of `Blast_Austin_Major_2025`). Since this is the Mongo db name, historic tournaments lose access to their old data — discussed and accepted as we don't use historic data.
- govulncheck stage of CI fails due to pre-existing crypto/tls vulnerabilities in stdlib — unrelated, tracked in #30.

## Test plan
- [x] `bash scripts/quality_check.sh` passes through coverage gate (80.7%, threshold 80%)
- [x] Configure script tested against multi-stage (IEM Cologne), multi-region (PGL Bucharest), single-stage (BLAST Bounty), and explicit `-stage` flag flows
- [x] Webhook tests updated and passing
- [ ] Manual verification once deployed: bot loads `config.toml` on startup and connects to the correct Mongo db / Liquipedia page

🤖 Generated with [Claude Code](https://claude.com/claude-code)