### PR TITLE
Uplift logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ PandaScore integration — second data source alongside Liquipedia:
 - `scripts/fetchtest`: new smoke-test tool — `go run ./scripts/fetchtest <liquipedia|pandascore> <page|seriesID> <round>` — verifies both data sources return well-formed match data before deploying.
 - `Dockerfile`: added comments listing all required runtime environment variables (`PANDASCORE_API_KEY` added alongside the existing secrets).
 
+Structured logging uplift — `log` → `slog` with JSON output:
+- Replaced all `log.*` calls in the bot runtime (`main`, `app`, `bot`, `store`, `web`) with `log/slog`. Logs are now emitted as structured JSON to stdout, ready for Promtail → Loki ingestion without any code changes.
+- Log level is configurable via `log_level` in `config.toml` (`debug`, `info`, `warn`, `error`). Defaults to `debug` when `test = true`, `info` otherwise.
+- Each major component (`app`, `store`, `bot`, `poller`, `web`) has its own injected `*slog.Logger` tagged with a `component` field, so every log line identifies its source without relying on message text.
+- `log.Fatalf` calls in Discord handlers replaced with `slog.Error` + `return` — a failed embed send no longer crashes the entire bot process.
+- Errors at log sites wrapped with `fmt.Errorf("functionName: %w", err)` to provide call-site breadcrumbs in the absence of stack traces.
+- Duplicate log entries eliminated: rate-limit events were previously logged in `app.go` and again by the caller; now logged once at the handling site only.
+- Poller continuable errors (transient fetch failures, parse errors, update/render failures) are `Warn`; only an unrecoverable API error that stops the poller is `Error`.
+- `scripts/configure` and `scripts/fetchtest` left unchanged — their `fmt.Printf` output is intentional CLI output, not application logging.
+
 Bug fixes and data layer improvements:
 - Fixed Swiss `$check` off-by-one: 3-0 and 0-3 buckets each showed 1 team instead of 2, advance showed 4 instead of 6. Root cause: `setSwissPredictions` divided the input list length by the wrong denominator.
 - Fixed `$results` for single-elimination: trimmed the 3rd-place consolation match that Liquipedia's `Bracket/8` template appends as an 8th node (the renderer only supports the 7-match main bracket). Also fixed column layout — Liquipedia returns all bracket nodes with `Section = "Bracket/8"`, causing the renderer to stack all matches in one column; sections are now normalised to `Quarterfinals` / `Semifinals` / `Grand Final` by match position before rendering.

--- a/app/app.go
+++ b/app/app.go
@@ -9,7 +9,7 @@ package app
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"pickems-bot/config"
 	"pickems-bot/models"
@@ -28,10 +28,20 @@ import (
 type App struct {
 	Store       store.Interface
 	rateLimiter *rate.Limiter
+	log         *slog.Logger
 }
 
-// NewApp creates a new App instance with the provided configuration
-func NewApp(cfg config.Config, mongoURI string) (*App, error) {
+// logger returns the app's logger, falling back to the global default when none was injected.
+func (a *App) logger() *slog.Logger {
+	if a.log == nil {
+		return slog.Default()
+	}
+	return a.log
+}
+
+// NewApp creates a new App instance with the provided configuration.
+// log may be nil; if so the global slog default is used.
+func NewApp(cfg config.Config, mongoURI string, log *slog.Logger) (*App, error) {
 	var fetcher store.DataSourceFetcher
 	var limiter *rate.Limiter
 	switch cfg.DataSource {
@@ -47,7 +57,14 @@ func NewApp(cfg config.Config, mongoURI string) (*App, error) {
 		return nil, fmt.Errorf("unsupported data source: %s", cfg.DataSource)
 	}
 
-	s, err := store.NewStore(cfg.TournamentName, mongoURI, cfg.Round, fetcher)
+	// Tag each layer's logger with its own component before storing, so that
+	// every log line carries exactly one "component" field without double-stamping.
+	var appLog, storeLog *slog.Logger
+	if log != nil {
+		appLog = log.With("component", "app")
+		storeLog = log.With("component", "store")
+	}
+	s, err := store.NewStore(cfg.TournamentName, mongoURI, cfg.Round, fetcher, storeLog)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize store: %w", err)
 	}
@@ -55,6 +72,7 @@ func NewApp(cfg config.Config, mongoURI string) (*App, error) {
 	return &App{
 		Store:       s,
 		rateLimiter: limiter,
+		log:         appLog,
 	}, nil
 }
 
@@ -199,7 +217,11 @@ func (a *App) GenerateLeaderboard() error {
 		if err != nil {
 			// Skip predictions that can't be scored — most likely a stale entry
 			// stored by an older code version or a different format for this round.
-			log.Printf("warning: skipping prediction for user %s (round=%s): %v", pred.Username, pred.Round, err)
+			a.logger().Warn("skipping prediction (stale or incompatible format)",
+				"user", pred.Username,
+				"round", pred.Round,
+				"error", err,
+			)
 			continue
 		}
 		scores := scoreReport.GetScore()
@@ -327,7 +349,6 @@ func (a *App) GetTournamentInfo() (TournamentInfo, error) {
 // When scheduleOnly is false, match results are also fetched and stored.
 func (a *App) PopulateMatches(scheduleOnly bool) error {
 	if !a.Allow() {
-		log.Printf("Rate limit exceeded")
 		return fmt.Errorf("rate limiter limit reached")
 	}
 
@@ -347,7 +368,6 @@ func (a *App) PopulateMatches(scheduleOnly bool) error {
 // across the app and ensuring we comply with api specifications
 func (a *App) UpdateMatchResults() error {
 	if !a.Allow() {
-		log.Println("Rate limiter is reached")
 		return fmt.Errorf("rate limiter exceeded, skipping match result update")
 	}
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -21,7 +21,7 @@ import (
 // region NewApp tests
 
 func TestNewApp_UnsupportedDataSource(t *testing.T) {
-	_, err := NewApp(config.Config{DataSource: "unknown", TournamentName: "db", Round: "r1"}, "mongodb://localhost")
+	_, err := NewApp(config.Config{DataSource: "unknown", TournamentName: "db", Round: "r1"}, "mongodb://localhost", nil)
 	if err == nil {
 		t.Error("Expected error for unsupported data source, got nil")
 	}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -8,6 +8,7 @@ package bot
 
 import (
 	"fmt"
+	"log/slog"
 	"pickems-bot/app"
 	"strings"
 )
@@ -16,17 +17,32 @@ import (
 type Bot struct {
 	BotToken string
 	APIPtr   *app.App
+	log      *slog.Logger
 }
 
-// NewBot creates a new Bot instance with the provided token and API pointer
-func NewBot(botToken string, apiPtr *app.App) (*Bot, error) {
+// logger returns the bot's logger, falling back to the global default when none was injected.
+func (b *Bot) logger() *slog.Logger {
+	if b.log == nil {
+		return slog.Default()
+	}
+	return b.log
+}
+
+// NewBot creates a new Bot instance with the provided token and API pointer.
+// log may be nil; if so the global slog default is used.
+func NewBot(botToken string, apiPtr *app.App, log *slog.Logger) (*Bot, error) {
 	if botToken == "" {
 		return nil, fmt.Errorf("botToken is required but none was provided")
 	}
 
+	var botLog *slog.Logger
+	if log != nil {
+		botLog = log.With("component", "bot")
+	}
 	return &Bot{
 		BotToken: botToken,
 		APIPtr:   apiPtr,
+		log:      botLog,
 	}, nil
 }
 

--- a/bot/bot_command_test.go
+++ b/bot/bot_command_test.go
@@ -29,7 +29,7 @@ func createMockAPI(kind tournament.Kind) *app.App {
 
 func TestNewBot_Success(t *testing.T) {
 	apiPtr := createMockAPI("swiss")
-	bot, err := NewBot("test_token", apiPtr)
+	bot, err := NewBot("test_token", apiPtr, nil)
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %s", err.Error())
@@ -46,7 +46,7 @@ func TestNewBot_Success(t *testing.T) {
 
 func TestNewBot_EmptyToken(t *testing.T) {
 	apiPtr := createMockAPI("swiss")
-	_, err := NewBot("", apiPtr)
+	_, err := NewBot("", apiPtr, nil)
 
 	if err == nil {
 		t.Error("Expected error for empty bot token, got nil")

--- a/bot/bot_runtime.go
+++ b/bot/bot_runtime.go
@@ -9,7 +9,6 @@
 package bot
 
 import (
-	"log"
 	"os"
 	"os/signal"
 
@@ -32,7 +31,7 @@ func (b *Bot) Run() error {
 	defer discord.Close() // close session, after function termination
 
 	// keep bot running until there is NO os interruption (ctrl + C)
-	log.Println("Pickems Bot started")
+	b.logger().Info("Pickems Bot started")
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c

--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -254,8 +254,8 @@ func (b *Bot) teamsHandler(session DiscordSession, message *discordgo.MessageCre
 		Title: "Teams in this Stage",
 		Color: green,
 		Fields: []*discordgo.MessageEmbedField{
-			{Name: "​", Value: leftCol.String(), Inline: true},
-			{Name: "​", Value: rightCol.String(), Inline: true},
+			{Name: "\u200b", Value: leftCol.String(), Inline: true},
+			{Name: "\u200b", Value: rightCol.String(), Inline: true},
 		},
 		Footer: &discordgo.MessageEmbedFooter{
 			Text: fmt.Sprintf("%d teams • Fuzzy matching is active, but keep names as close as possible!", len(teams)),

--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -9,7 +9,6 @@ package bot
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"pickems-bot/models"
 	"pickems-bot/tournament"
@@ -75,7 +74,7 @@ func (b *Bot) helpMessageHandler(session DiscordSession, message *discordgo.Mess
 	}
 
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-		log.Fatalf("send embed: %v", err)
+		b.logger().Error("failed to send help embed", "error", fmt.Errorf("helpMessageHandler: %w", err))
 	}
 }
 
@@ -83,7 +82,7 @@ func (b *Bot) helpMessageHandler(session DiscordSession, message *discordgo.Mess
 func (b *Bot) detailsHandler(session DiscordSession, message *discordgo.MessageCreate) {
 	info, err := b.APIPtr.GetTournamentInfo()
 	if err != nil {
-		log.Println(err)
+		b.logger().Error("failed to get tournament info", "error", fmt.Errorf("detailsHandler: %w", err))
 		sendError(session, message.ChannelID, "An unexpected error occurred.")
 		return
 	}
@@ -116,7 +115,7 @@ func (b *Bot) detailsHandler(session DiscordSession, message *discordgo.MessageC
 	}
 
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-		log.Fatalf("send embed: %v", err)
+		b.logger().Error("failed to send details embed", "error", fmt.Errorf("detailsHandler: %w", err))
 	}
 }
 
@@ -131,7 +130,7 @@ func (b *Bot) setPredictionsHandler(session DiscordSession, message *discordgo.M
 
 	err := b.APIPtr.SetUserPrediction(user, userPreds, b.APIPtr.Store.GetRound())
 	if err != nil {
-		log.Println(err)
+		b.logger().Error("failed to set user prediction", "user", user.Username, "error", fmt.Errorf("setPredictionsHandler: %w", err))
 		sendError(session, message.ChannelID, err.Error())
 		return
 	}
@@ -142,7 +141,7 @@ func (b *Bot) setPredictionsHandler(session DiscordSession, message *discordgo.M
 		Color:       green,
 	}
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-		log.Printf("send embed: %v", err)
+		b.logger().Error("failed to send set-predictions embed", "error", fmt.Errorf("setPredictionsHandler: %w", err))
 	}
 }
 
@@ -154,7 +153,7 @@ func (b *Bot) checkPredictionsHandler(session DiscordSession, message *discordgo
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			sendError(session, message.ChannelID, fmt.Sprintf("%s does not have any Pick'Ems stored. Use `$set` to set your predictions.", user.Username))
 		} else {
-			log.Println(err)
+			b.logger().Error("failed to check prediction", "user", user.Username, "error", fmt.Errorf("checkPredictionsHandler: %w", err))
 			sendError(session, message.ChannelID, fmt.Sprintf("An error occurred checking %s's Pick'Ems.", user.Username))
 		}
 		return
@@ -174,7 +173,7 @@ func (b *Bot) checkPredictionsHandler(session DiscordSession, message *discordgo
 
 	info, err := b.APIPtr.GetTournamentInfo()
 	if err != nil {
-		log.Println(err)
+		b.logger().Error("failed to get tournament info", "error", fmt.Errorf("checkPredictionsHandler: %w", err))
 		sendError(session, message.ChannelID, "An unexpected error occurred.")
 		return
 	}
@@ -187,7 +186,7 @@ func (b *Bot) checkPredictionsHandler(session DiscordSession, message *discordgo
 	}
 
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-		log.Printf("send embed: %v", err)
+		b.logger().Error("failed to send check-predictions embed", "user", user.Username, "error", fmt.Errorf("checkPredictionsHandler: %w", err))
 	}
 }
 
@@ -195,7 +194,7 @@ func (b *Bot) checkPredictionsHandler(session DiscordSession, message *discordgo
 func (b *Bot) leaderboardHandler(session DiscordSession, message *discordgo.MessageCreate) {
 	leaderboard, err := b.APIPtr.GetLeaderboard()
 	if err != nil {
-		log.Println(err)
+		b.logger().Error("failed to get leaderboard", "error", fmt.Errorf("leaderboardHandler: %w", err))
 		sendError(session, message.ChannelID, "An error occurred getting the leaderboard.")
 		return
 	}
@@ -224,7 +223,7 @@ func (b *Bot) leaderboardHandler(session DiscordSession, message *discordgo.Mess
 	}
 
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-		log.Fatalf("send embed: %v", err)
+		b.logger().Error("failed to send leaderboard embed", "error", fmt.Errorf("leaderboardHandler: %w", err))
 	}
 }
 
@@ -232,7 +231,7 @@ func (b *Bot) leaderboardHandler(session DiscordSession, message *discordgo.Mess
 func (b *Bot) teamsHandler(session DiscordSession, message *discordgo.MessageCreate) {
 	teams, err := b.APIPtr.GetTeams()
 	if err != nil {
-		log.Println(err)
+		b.logger().Error("failed to get teams", "error", fmt.Errorf("teamsHandler: %w", err))
 		sendError(session, message.ChannelID, "An error occurred getting the teams list.")
 		return
 	}
@@ -255,8 +254,8 @@ func (b *Bot) teamsHandler(session DiscordSession, message *discordgo.MessageCre
 		Title: "Teams in this Stage",
 		Color: green,
 		Fields: []*discordgo.MessageEmbedField{
-			{Name: "\u200b", Value: leftCol.String(), Inline: true},
-			{Name: "\u200b", Value: rightCol.String(), Inline: true},
+			{Name: "​", Value: leftCol.String(), Inline: true},
+			{Name: "​", Value: rightCol.String(), Inline: true},
 		},
 		Footer: &discordgo.MessageEmbedFooter{
 			Text: fmt.Sprintf("%d teams • Fuzzy matching is active, but keep names as close as possible!", len(teams)),
@@ -264,7 +263,7 @@ func (b *Bot) teamsHandler(session DiscordSession, message *discordgo.MessageCre
 	}
 
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-		log.Printf("send embed: %v", err)
+		b.logger().Error("failed to send teams embed", "error", fmt.Errorf("teamsHandler: %w", err))
 	}
 }
 
@@ -272,7 +271,7 @@ func (b *Bot) teamsHandler(session DiscordSession, message *discordgo.MessageCre
 func (b *Bot) upcomingMatchesHandler(session DiscordSession, message *discordgo.MessageCreate) {
 	matches, err := b.APIPtr.GetUpcomingMatches()
 	if err != nil {
-		log.Println(err)
+		b.logger().Error("failed to get upcoming matches", "error", fmt.Errorf("upcomingMatchesHandler: %w", err))
 		sendError(session, message.ChannelID, "An error occurred getting upcoming matches.")
 		return
 	}
@@ -284,7 +283,7 @@ func (b *Bot) upcomingMatchesHandler(session DiscordSession, message *discordgo.
 			Color:       green,
 		}
 		if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-			log.Printf("send embed: %v", err)
+			b.logger().Error("failed to send upcoming-matches embed", "error", fmt.Errorf("upcomingMatchesHandler: %w", err))
 		}
 		return
 	}
@@ -311,7 +310,7 @@ func (b *Bot) upcomingMatchesHandler(session DiscordSession, message *discordgo.
 	}
 
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
-		log.Printf("send embed: %v", err)
+		b.logger().Error("failed to send upcoming-matches embed", "error", fmt.Errorf("upcomingMatchesHandler: %w", err))
 	}
 }
 
@@ -324,7 +323,7 @@ func (b *Bot) resultsHandler(session DiscordSession, message *discordgo.MessageC
 	// Load image from disk
 	f, err := os.Open(outputPath)
 	if err != nil {
-		log.Printf("open png: %v", err)
+		b.logger().Error("failed to open results image", "path", outputPath, "error", fmt.Errorf("resultsHandler: %w", err))
 		sendError(session, message.ChannelID, "An error occurred fetching the match results.")
 		return
 	}

--- a/bot/utils.go
+++ b/bot/utils.go
@@ -2,7 +2,7 @@ package bot
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	format "pickems-bot/tournament"
 	"regexp"
 	"sort"
@@ -102,6 +102,6 @@ func sendError(session DiscordSession, channelID string, msg string) {
 		Color:       red,
 	}
 	if _, err := session.ChannelMessageSendEmbed(channelID, embed); err != nil {
-		log.Printf("send error embed: %v", err)
+		slog.Error("failed to send error embed", "error", fmt.Errorf("sendError: %w", err))
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,11 @@ type Config struct {
 	// Bot modes
 	UpcomingOnly bool `toml:"upcoming_only"`
 	Test         bool `toml:"test"`
+
+	// Logging
+	// LogLevel controls the minimum log level emitted (debug, info, warn, error).
+	// Defaults to "info". When test=true and log_level is unset, defaults to "debug".
+	LogLevel string `toml:"log_level"`
 }
 
 // Load reads and validates a config.toml file at path.

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	"pickems-bot/app"
@@ -25,17 +25,35 @@ import (
 
 func main() {
 	if err := godotenv.Load(); err != nil {
-		log.Println("No .env file found, using environment variables")
+		slog.Info("no .env file found, using environment variables")
 	}
 
 	cfg, err := config.Load("config.toml")
 	if err != nil {
-		log.Fatalf("failed to load config: %v", err)
+		slog.Error("failed to load config", "error", err)
+		os.Exit(1)
 	}
 
-	apiInstance, err := app.NewApp(cfg, os.Getenv("MONGO_PROD_URI"))
+	// Determine log level: explicit config value wins; otherwise debug in test
+	// mode and info in production.
+	level := slog.LevelInfo
+	if cfg.LogLevel != "" {
+		if parseErr := level.UnmarshalText([]byte(cfg.LogLevel)); parseErr != nil {
+			slog.Warn("unrecognised log_level in config.toml, defaulting to info", "value", cfg.LogLevel)
+			level = slog.LevelInfo
+		}
+	} else if cfg.Test {
+		level = slog.LevelDebug
+	}
+
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	apiInstance, err := app.NewApp(cfg, os.Getenv("MONGO_PROD_URI"), logger)
 	if err != nil {
-		log.Fatalf("failed to initialize API: %v", err)
+		logger.Error("failed to initialize app", "error", err)
+		os.Exit(1)
 	}
 	defer func() {
 		if err = apiInstance.Store.GetClient().Disconnect(context.TODO()); err != nil {
@@ -43,12 +61,18 @@ func main() {
 		}
 	}()
 
+	logger.Debug("populating matches from data source", "source", cfg.DataSource, "schedule_only", cfg.UpcomingOnly)
 	if err := apiInstance.PopulateMatches(cfg.UpcomingOnly); err != nil {
-		log.Fatal(err)
+		logger.Error("failed to populate matches", "error", err)
+		os.Exit(1)
 	}
+	logger.Debug("match data populated")
+
 	if err := apiInstance.GenerateLeaderboard(); err != nil {
-		log.Fatal(err)
+		logger.Error("failed to generate leaderboard", "error", err)
+		os.Exit(1)
 	}
+	logger.Debug("leaderboard generated")
 
 	// Regenerate the result image on startup so it always reflects the current
 	// tournament/bracket. The image on disk can be stale if the bot was previously
@@ -57,8 +81,10 @@ func main() {
 	// mode there are no match results yet so this is expected to fail; skip it.
 	if !cfg.UpcomingOnly {
 		if err := web.RenderResultsImage(apiInstance); err != nil {
-			log.Fatalf("could not render results image on startup: %v", err)
+			logger.Error("could not render results image on startup", "error", err)
+			os.Exit(1)
 		}
+		logger.Debug("results image rendered")
 	}
 
 	var discordToken string
@@ -67,28 +93,32 @@ func main() {
 	} else {
 		discordToken = os.Getenv("DISCORD_PROD_TOKEN")
 	}
-	botInstance, err := bot.NewBot(discordToken, apiInstance)
+	botInstance, err := bot.NewBot(discordToken, apiInstance, logger)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("failed to initialize bot", "error", err)
+		os.Exit(1)
 	}
 
 	switch cfg.DataSource {
 	case "pandascore":
-		poller := web.NewPoller(apiInstance, cfg.SeriesID, os.Getenv("PANDASCORE_API_KEY"))
+		poller := web.NewPoller(apiInstance, cfg.SeriesID, os.Getenv("PANDASCORE_API_KEY"), logger)
 		go poller.Start()
-		log.Println("PandaScore poller started")
+		logger.Info("PandaScore poller started")
 	case "liquipedia":
 		go func() {
-			if err := web.Start(web.Config{Addr: ":8080", API: apiInstance, Page: cfg.Page}); err != nil {
-				log.Fatalf("failed to start web server: %v", err)
+			if err := web.Start(web.Config{Addr: ":8080", API: apiInstance, Page: cfg.Page, Logger: logger}); err != nil {
+				logger.Error("web server exited", "error", err)
+				os.Exit(1)
 			}
 		}()
-		log.Println("Liquipedia webhook server starting on :8080")
+		logger.Info("Liquipedia webhook server starting", "addr", ":8080")
 	default:
-		log.Fatalf("unknown data_source %q in config.toml", cfg.DataSource)
+		logger.Error("unknown data_source in config.toml", "data_source", cfg.DataSource)
+		os.Exit(1)
 	}
 
 	if err := botInstance.Run(); err != nil {
-		log.Fatal(fmt.Errorf("an unrecoverable error occured whilst running the bot: %w", err))
+		logger.Error("unrecoverable error running the bot", "error", fmt.Errorf("bot.Run: %w", err))
+		os.Exit(1)
 	}
 }

--- a/store/leaderboard.go
+++ b/store/leaderboard.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -54,7 +53,7 @@ func (s *Store) StoreLeaderboard(leaderboard Leaderboard) error {
 	}
 
 	// Perform insert or update
-	log.Println("updating leaderboard in db")
+	s.logger().Info("updating leaderboard in db", "round", s.Round)
 	if notFound {
 		_, err := s.Collections.Leaderboard.InsertOne(context.TODO(), leaderboard)
 		if err != nil {

--- a/store/match_results.go
+++ b/store/match_results.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	"pickems-bot/tournament"
 
@@ -115,7 +114,7 @@ func (s *Store) FetchAndUpdateMatchResults() error {
 		return err
 	}
 	if err := s.StoreMatchNodes(nodes, result.GetType()); err != nil {
-		log.Printf("warning: failed to store match nodes: %v", err)
+		s.logger().Warn("failed to store match nodes", "error", fmt.Errorf("FetchAndUpdateMatchResults: %w", err))
 	}
 	return nil
 }

--- a/store/match_schedule.go
+++ b/store/match_schedule.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"pickems-bot/sources"
 	"sort"
 
@@ -59,7 +58,7 @@ func (s *Store) StoreMatchSchedule(scheduledMatches []sources.ScheduledMatch) er
 	}
 	update := bson.M{"$set": upcomingMatchDoc}
 
-	log.Println("updating match schedule in db")
+	s.logger().Info("updating match schedule in db", "round", s.Round)
 
 	// Perform insert or update
 	if notFound {

--- a/store/store.go
+++ b/store/store.go
@@ -9,6 +9,7 @@ package store
 
 import (
 	"context"
+	"log/slog"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -27,10 +28,20 @@ type Store struct {
 		Leaderboard   *mongo.Collection
 	}
 	Fetcher DataSourceFetcher
+	log     *slog.Logger
 }
 
-// NewStore initializes Store. Sets global values and initialises db connection
-func NewStore(dbName string, mongoURI string, round string, fetcher DataSourceFetcher) (*Store, error) {
+// logger returns the store's logger, falling back to the global default when none was injected.
+func (s *Store) logger() *slog.Logger {
+	if s.log == nil {
+		return slog.Default()
+	}
+	return s.log
+}
+
+// NewStore initializes Store. Sets global values and initialises db connection.
+// log may be nil; if so the global slog default is used.
+func NewStore(dbName string, mongoURI string, round string, fetcher DataSourceFetcher, log *slog.Logger) (*Store, error) {
 	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(mongoURI))
 	if err != nil {
 		return nil, err
@@ -55,6 +66,7 @@ func NewStore(dbName string, mongoURI string, round string, fetcher DataSourceFe
 			Leaderboard:   db.Collection("leaderboard"),
 		},
 		Fetcher: fetcher,
+		log:     log,
 	}, nil
 }
 

--- a/store/test_helpers.go
+++ b/store/test_helpers.go
@@ -20,7 +20,7 @@ import (
 // NewMockStore creates a Store instance for testing purposes.
 // This can be used with a real test database or in-memory MongoDB.
 func NewMockStore(dbName string, mongoURI string) (*Store, error) {
-	return NewStore(dbName, mongoURI, "test_round", NewLiquipediaFetcher("", "Test/Tournament/2025"))
+	return NewStore(dbName, mongoURI, "test_round", NewLiquipediaFetcher("", "Test/Tournament/2025"), nil)
 }
 
 // CreateTestStore creates a Store connected to a test database.

--- a/web/liquipedia.go
+++ b/web/liquipedia.go
@@ -3,7 +3,6 @@ package web
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -42,7 +41,7 @@ func (s *Server) LiquipediaWebhookHandler(w http.ResponseWriter, r *http.Request
 
 	var event LiquipediaEvent
 	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
-		log.Println("failed to decode webhook:", err)
+		s.logger().Error("failed to decode webhook body", "error", fmt.Errorf("LiquipediaWebhookHandler: %w", err))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -56,20 +55,20 @@ func (s *Server) LiquipediaWebhookHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	log.Printf("Recieved relevant webhook, running update functions")
+	s.logger().Info("received relevant webhook, running update pipeline", "page", event.Page)
 
 	// Kick async pipeline – call into your existing packages (/api, /bot, etc)
 	go func(e LiquipediaEvent) {
 		if err := s.api.UpdateMatchResults(); err != nil {
-			log.Println("RefreshTournamentData failed:", err)
+			s.logger().Error("update match results failed", "error", fmt.Errorf("webhook pipeline: %w", err))
 			return
 		}
 		if err := s.api.GenerateLeaderboard(); err != nil {
-			log.Println("RecalculateAndStoreLeaderboard failed:", err)
+			s.logger().Error("generate leaderboard failed", "error", fmt.Errorf("webhook pipeline: %w", err))
 			return
 		}
 		if err := RenderResultsImage(s.api); err != nil {
-			log.Println("RenderResultsImage failed:", err)
+			s.logger().Error("render results image failed", "error", fmt.Errorf("webhook pipeline: %w", err))
 		}
 	}(event)
 

--- a/web/poller.go
+++ b/web/poller.go
@@ -2,7 +2,8 @@ package web
 
 import (
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
 	"pickems-bot/app"
 	"pickems-bot/sources"
 	"time"
@@ -16,16 +17,31 @@ type Poller struct {
 	apiKey      string
 	interval    time.Duration
 	knownStatus map[string]string // matchID -> last known status
+	log         *slog.Logger
 }
 
-// NewPoller is the poller constructor
-func NewPoller(a *app.App, seriesID int, apiKey string) *Poller {
+// logger returns the poller's logger, falling back to the global default when none was injected.
+func (p *Poller) logger() *slog.Logger {
+	if p.log == nil {
+		return slog.Default()
+	}
+	return p.log
+}
+
+// NewPoller is the poller constructor.
+// log may be nil; if so the global slog default is used.
+func NewPoller(a *app.App, seriesID int, apiKey string, log *slog.Logger) *Poller {
+	var pollerLog *slog.Logger
+	if log != nil {
+		pollerLog = log.With("component", "poller")
+	}
 	return &Poller{
 		app:         a,
 		seriesID:    seriesID,
 		apiKey:      apiKey,
 		interval:    time.Minute,
 		knownStatus: make(map[string]string),
+		log:         pollerLog,
 	}
 }
 
@@ -36,7 +52,6 @@ func (p *Poller) Start() {
 
 	for range ticker.C {
 		if !p.tick() {
-			log.Println("Poller: stopping due to unrecoverable error")
 			return
 		}
 	}
@@ -47,19 +62,23 @@ func (p *Poller) Start() {
 func (p *Poller) tick() bool {
 	// make sure we are not exceeding our rate limiter limitation
 	if !p.app.Allow() {
-		log.Println("Poller: rate limit reached, skipping tick")
+		p.logger().Warn("rate limit reached, skipping tick")
 		return true
 	}
 
 	raw, err := sources.GetPandaScoreMatches(p.apiKey, p.seriesID)
 	if err != nil {
-		log.Printf("Poller: fetch error: %v", err)
-		return !errors.Is(err, sources.ErrUnrecoverable)
+		if errors.Is(err, sources.ErrUnrecoverable) {
+			p.logger().Error("unrecoverable fetch error, stopping poller", "error", fmt.Errorf("poller.tick: %w", err))
+			return false
+		}
+		p.logger().Warn("failed to fetch matches from PandaScore, will retry next tick", "error", fmt.Errorf("poller.tick: %w", err))
+		return true
 	}
 
 	matchNodes, err := sources.ParsePandaScoreMatches(raw)
 	if err != nil {
-		log.Printf("Poller: parse error: %v", err)
+		p.logger().Warn("failed to parse PandaScore matches, will retry next tick", "error", fmt.Errorf("poller.tick: %w", err))
 		return true
 	}
 
@@ -72,15 +91,17 @@ func (p *Poller) tick() bool {
 		p.knownStatus[matchNode.ID] = matchNode.Status
 	}
 
+	p.logger().Debug("poller tick complete", "matches_checked", len(matchNodes), "finished_transition", finishedTransition)
+
 	if finishedTransition {
 		if err := p.app.UpdateMatchResults(); err != nil {
-			log.Printf("Poller: update match results error: %v", err)
+			p.logger().Warn("failed to update match results", "error", fmt.Errorf("poller.tick: %w", err))
 		}
 		if err := p.app.GenerateLeaderboard(); err != nil {
-			log.Printf("Poller: generate leaderboard error: %v", err)
+			p.logger().Warn("failed to generate leaderboard", "error", fmt.Errorf("poller.tick: %w", err))
 		}
 		if err := RenderResultsImage(p.app); err != nil {
-			log.Printf("Poller: render results image error: %v", err)
+			p.logger().Warn("failed to render results image", "error", fmt.Errorf("poller.tick: %w", err))
 		}
 	}
 

--- a/web/poller_test.go
+++ b/web/poller_test.go
@@ -15,13 +15,13 @@ import (
 // region NewPoller tests
 
 func TestNewPoller_DefaultInterval(t *testing.T) {
-	p := NewPoller(nil, 42, "test-key")
+	p := NewPoller(nil, 42, "test-key", nil)
 
 	assert.Equal(t, time.Minute, p.interval)
 }
 
 func TestNewPoller_Fields(t *testing.T) {
-	p := NewPoller(nil, 99, "my-api-key")
+	p := NewPoller(nil, 99, "my-api-key", nil)
 
 	assert.Nil(t, p.app)
 	assert.Equal(t, 99, p.seriesID)
@@ -30,7 +30,7 @@ func TestNewPoller_Fields(t *testing.T) {
 
 func TestNewPoller_KnownStatusInitialised(t *testing.T) {
 	// knownStatus map must be initialised — a nil map panics on write
-	p := NewPoller(nil, 1, "key")
+	p := NewPoller(nil, 1, "key", nil)
 
 	assert.NotNil(t, p.knownStatus)
 	// writing to it should not panic
@@ -42,7 +42,7 @@ func TestNewPoller_KnownStatusInitialised(t *testing.T) {
 // region knownStatus transition logic tests
 
 func TestPoller_StatusTransition_DetectsFinished(t *testing.T) {
-	p := NewPoller(nil, 1, "key")
+	p := NewPoller(nil, 1, "key", nil)
 	p.knownStatus["match-1"] = "running"
 
 	// Simulate a tick where match-1 transitions to finished
@@ -63,7 +63,7 @@ func TestPoller_StatusTransition_DetectsFinished(t *testing.T) {
 
 func TestPoller_StatusTransition_NoTriggerIfAlreadyFinished(t *testing.T) {
 	// A match already marked finished should not trigger again on next tick
-	p := NewPoller(nil, 1, "key")
+	p := NewPoller(nil, 1, "key", nil)
 	p.knownStatus["match-1"] = "finished"
 
 	finishedTransition := false
@@ -83,7 +83,7 @@ func TestPoller_StatusTransition_NoTriggerIfAlreadyFinished(t *testing.T) {
 func TestPoller_StatusTransition_NoTriggerForFirstSeen(t *testing.T) {
 	// A brand-new match seen as "finished" (never tracked before) should not trigger —
 	// we only react to transitions, not initial state.
-	p := NewPoller(nil, 1, "key")
+	p := NewPoller(nil, 1, "key", nil)
 
 	finishedTransition := false
 	statuses := map[string]string{"match-new": "finished"}

--- a/web/server.go
+++ b/web/server.go
@@ -7,7 +7,7 @@
 package web
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"pickems-bot/app"
 	"time"
@@ -15,22 +15,37 @@ import (
 
 // Config holds the configuration for the web server
 type Config struct {
-	Addr string
-	API  *app.App
-	Page string // Liquipedia page path, used for webhook filtering
+	Addr   string
+	API    *app.App
+	Page   string // Liquipedia page path, used for webhook filtering
+	Logger *slog.Logger
 }
 
 // Server is the HTTP server that handles webhook requests
 type Server struct {
 	api  *app.App
 	page string // Liquipedia page path, used for webhook filtering
+	log  *slog.Logger
+}
+
+// logger returns the server's logger, falling back to the global default when none was injected.
+func (s *Server) logger() *slog.Logger {
+	if s.log == nil {
+		return slog.Default()
+	}
+	return s.log
 }
 
 // Start initializes and starts the HTTP server with the given configuration
 func Start(cfg Config) error {
+	var serverLog *slog.Logger
+	if cfg.Logger != nil {
+		serverLog = cfg.Logger.With("component", "web")
+	}
 	s := &Server{
 		api:  cfg.API,
 		page: cfg.Page,
+		log:  serverLog,
 	}
 
 	mux := http.NewServeMux()
@@ -43,6 +58,6 @@ func Start(cfg Config) error {
 		WriteTimeout: 5 * time.Second,
 	}
 
-	log.Println("HTTP server listening on", cfg.Addr)
+	s.logger().Info("HTTP server listening", "addr", cfg.Addr)
 	return srv.ListenAndServe()
 }


### PR DESCRIPTION
Uplifted logging. Previously, logs were an after thought. There was a mix of non-helpful print statements and logs for things. This PR uplifts the entire project to use slog, which gives a structured approach to logging. The log instance is shared across all packages with logging. (might want to turn into a proper singleton at some point, probably more idiomatic). This will help with debugging issues in future, and provides a proper standard for logging in new features