### PR TITLE
feat: add integration test suite with test server wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,42 @@ jobs:
         with:
           name: coverage-report
           path: coverage.out
+
+  integration-test:
+    name: Integration Tests
+    needs: build-and-quality
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: read  # allows GITHUB_TOKEN to pull from GHCR
+
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+
+      test-server:
+        image: ghcr.io/zacharyab24/pickems-test-server:latest
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        ports:
+          - 8081:8081
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Run integration tests
+        env:
+          MONGO_PROD_URI: mongodb://localhost:27017
+        run: go test -tags integration -timeout 120s -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 *.out
 coverage
 config.toml
-resources/result.png
+**/resources/result.png

--- a/app/app.go
+++ b/app/app.go
@@ -46,11 +46,11 @@ func NewApp(cfg config.Config, mongoURI string, log *slog.Logger) (*App, error) 
 	var limiter *rate.Limiter
 	switch cfg.DataSource {
 	case "liquipedia":
-		fetcher = store.NewLiquipediaFetcher(os.Getenv("LIQUIDPEDIADB_API_KEY"), cfg.Page)
+		fetcher = store.NewLiquipediaFetcher(cfg.Liquipedia.APIURL, os.Getenv("LIQUIDPEDIADB_API_KEY"), cfg.Liquipedia.Page)
 		limiter = rate.NewLimiter(rate.Every(time.Minute), 10) // 60/hr per API guidelines
 
 	case "pandascore":
-		fetcher = store.NewPandaScoreFetcher(os.Getenv("PANDASCORE_API_KEY"), cfg.SeriesID)
+		fetcher = store.NewPandaScoreFetcher(cfg.PandaScore.APIURL, os.Getenv("PANDASCORE_API_KEY"), cfg.PandaScore.SeriesID)
 		limiter = rate.NewLimiter(rate.Every(4*time.Second), 5) // ~900/hr, less than the 1000 limit of our api plan
 
 	default:

--- a/app/app_integration_test.go
+++ b/app/app_integration_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+package app
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"pickems-bot/config"
+	"pickems-bot/sources"
+	"pickems-bot/testhelpers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+// loadIntegrationConfig loads the shared integration test config.
+func loadIntegrationConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.Load("../testdata/integration_config.toml")
+	require.NoError(t, err, "failed to load integration_config.toml")
+	return cfg
+}
+
+// newTestApp creates an App connected to the test MongoDB using the provided config.
+// The rate limiter is set to allow calls immediately so tests are not gated.
+// t.Cleanup disconnects the client and drops the test database.
+func newTestApp(t *testing.T, cfg config.Config, mongoURI string) *App {
+	t.Helper()
+	a, err := NewApp(cfg, mongoURI, slog.Default())
+	require.NoError(t, err, "NewApp failed")
+
+	// Override the rate limiter to allow unlimited calls so rapid sequential
+	// calls within a single test are never gated.
+	a.rateLimiter = rate.NewLimiter(rate.Inf, 1)
+
+	t.Cleanup(func() {
+		_ = a.Store.GetClient().Disconnect(context.Background())
+	})
+	return a
+}
+
+// ───────────────────────────── PandaScore ─────────────────────────────
+
+// TestApp_PandaScore_InitialFetch verifies that PopulateMatches with the
+// test server in "ongoing" state stores a non-empty set of match nodes.
+func TestApp_PandaScore_InitialFetch(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	t.Setenv("PANDASCORE_API_KEY", "pickems-test-key")
+
+	testhelpers.SetState(t, "pandascore", "ongoing")
+
+	cfg := loadIntegrationConfig(t)
+	a := newTestApp(t, cfg, mongoURI)
+
+	require.NoError(t, a.PopulateMatches(false))
+
+	nodes, _, err := a.Store.FetchMatchNodesFromDb()
+	require.NoError(t, err)
+	assert.NotEmpty(t, nodes, "expected match nodes to be stored after PopulateMatches")
+}
+
+// TestApp_PandaScore_Empty verifies that PopulateMatches with the test server
+// in "not_started" state either returns an error or leaves the store empty
+// without panicking.
+func TestApp_PandaScore_Empty(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	t.Setenv("PANDASCORE_API_KEY", "pickems-test-key")
+
+	testhelpers.SetState(t, "pandascore", "not_started")
+
+	cfg := loadIntegrationConfig(t)
+	a := newTestApp(t, cfg, mongoURI)
+
+	err := a.PopulateMatches(false)
+	// Either an error is returned, or the store is empty — the bot must not crash.
+	if err == nil {
+		nodes, _, dbErr := a.Store.FetchMatchNodesFromDb()
+		require.NoError(t, dbErr)
+		assert.Empty(t, nodes, "expected no match nodes stored for empty response")
+	}
+	// err != nil is also acceptable; just ensure no panic occurred.
+}
+
+// TestApp_PandaScore_NotFound verifies that an unknown series ID causes
+// PopulateMatches to return an ErrUnrecoverable error.
+func TestApp_PandaScore_NotFound(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	t.Setenv("PANDASCORE_API_KEY", "pickems-test-key")
+
+	// Use a series_id that the test server doesn't recognise → 404.
+	cfg := loadIntegrationConfig(t)
+	cfg.PandaScore.SeriesID = 12345 // anything other than 99001 triggers 404
+	a := newTestApp(t, cfg, mongoURI)
+
+	err := a.PopulateMatches(false)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sources.ErrUnrecoverable),
+		"expected ErrUnrecoverable for unknown series ID, got: %v", err)
+}
+
+// TestApp_PandaScore_WrongKey verifies that a bad API key causes PopulateMatches
+// to return an ErrUnrecoverable error.
+func TestApp_PandaScore_WrongKey(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	t.Setenv("PANDASCORE_API_KEY", "wrong-key")
+
+	testhelpers.SetState(t, "pandascore", "ongoing")
+
+	cfg := loadIntegrationConfig(t)
+	a := newTestApp(t, cfg, mongoURI)
+
+	err := a.PopulateMatches(false)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sources.ErrUnrecoverable),
+		"expected ErrUnrecoverable for bad API key, got: %v", err)
+}
+
+// ───────────────────────────── Liquipedia ─────────────────────────────
+
+// TestApp_Liquipedia_InitialFetch verifies that PopulateMatches with the test
+// server in "ongoing" state stores match nodes using the Liquipedia source.
+func TestApp_Liquipedia_InitialFetch(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	t.Setenv("LIQUIDPEDIADB_API_KEY", "pickems-test-key")
+
+	testhelpers.SetState(t, "liquipedia", "ongoing")
+
+	cfg := loadIntegrationConfig(t)
+	cfg.DataSource = "liquipedia"
+	a := newTestApp(t, cfg, mongoURI)
+
+	require.NoError(t, a.PopulateMatches(false))
+
+	nodes, _, err := a.Store.FetchMatchNodesFromDb()
+	require.NoError(t, err)
+	assert.NotEmpty(t, nodes, "expected match nodes to be stored after Liquipedia fetch")
+}
+
+// TestApp_Liquipedia_Empty verifies that PopulateMatches with the test server
+// in "not_started" state either returns an error or leaves the store empty.
+func TestApp_Liquipedia_Empty(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	t.Setenv("LIQUIDPEDIADB_API_KEY", "pickems-test-key")
+
+	testhelpers.SetState(t, "liquipedia", "not_started")
+
+	cfg := loadIntegrationConfig(t)
+	cfg.DataSource = "liquipedia"
+	a := newTestApp(t, cfg, mongoURI)
+
+	err := a.PopulateMatches(false)
+	if err == nil {
+		nodes, _, dbErr := a.Store.FetchMatchNodesFromDb()
+		require.NoError(t, dbErr)
+		assert.Empty(t, nodes, "expected no match nodes stored for empty Liquipedia response")
+	}
+}
+
+// TestApp_Liquipedia_WrongKey verifies that a bad Liquipedia API key causes an error.
+func TestApp_Liquipedia_WrongKey(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	t.Setenv("LIQUIDPEDIADB_API_KEY", "wrong-key")
+
+	testhelpers.SetState(t, "liquipedia", "ongoing")
+
+	cfg := loadIntegrationConfig(t)
+	cfg.DataSource = "liquipedia"
+	a := newTestApp(t, cfg, mongoURI)
+
+	err := a.PopulateMatches(false)
+	require.Error(t, err, "expected error for bad Liquipedia API key")
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -610,6 +610,51 @@ func TestUpdateMatchResults_StoreError(t *testing.T) {
 
 // endregion
 
+// region logger tests
+
+func TestApp_Logger_NilLogger_ReturnsDefault(t *testing.T) {
+	a := &App{}
+	// logger() must not panic and must return slog.Default()
+	l := a.logger()
+	if l == nil {
+		t.Error("Expected non-nil logger when no logger injected")
+	}
+}
+
+// endregion
+
+// region PopulateMatches success paths
+
+func TestPopulateMatches_ScheduleOnly_Success(t *testing.T) {
+	mockStore := NewMockStore("swiss", "test_round")
+
+	api := &App{
+		Store:       mockStore,
+		rateLimiter: rate.NewLimiter(rate.Every(time.Second), 10),
+	}
+
+	err := api.PopulateMatches(true)
+	if err != nil {
+		t.Errorf("Expected no error for scheduleOnly=true, got: %s", err.Error())
+	}
+}
+
+func TestPopulateMatches_FullUpdate_Success(t *testing.T) {
+	mockStore := NewMockStore("swiss", "test_round")
+
+	api := &App{
+		Store:       mockStore,
+		rateLimiter: rate.NewLimiter(rate.Every(time.Second), 10),
+	}
+
+	err := api.PopulateMatches(false)
+	if err != nil {
+		t.Errorf("Expected no error for scheduleOnly=false, got: %s", err.Error())
+	}
+}
+
+// endregion
+
 // region PopulateMatches rate limiter tests
 
 func TestPopulateMatches_RateLimiterNil(t *testing.T) {

--- a/app/integration_helpers.go
+++ b/app/integration_helpers.go
@@ -1,0 +1,13 @@
+//go:build integration
+
+package app
+
+import "golang.org/x/time/rate"
+
+// SetRateLimiterForTesting replaces the App's rate limiter with the given one.
+// Only compiled under the integration build tag; used by integration tests in
+// other packages that need to override rate limiting without touching unexported
+// fields directly.
+func SetRateLimiterForTesting(a *App, l *rate.Limiter) {
+	a.rateLimiter = l
+}

--- a/app/test_mocks.go
+++ b/app/test_mocks.go
@@ -15,6 +15,7 @@ import (
 	"pickems-bot/tournament"
 
 	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/time/rate"
 )
 
 // MockStore implements the Store interface for testing
@@ -249,4 +250,14 @@ func (m *MockStore) FetchLeaderboardFromDB() ([]store.LeaderboardEntry, error) {
 		return nil, m.FetchLeaderboardFromDBError
 	}
 	return m.Leaderboard, nil
+}
+
+// NewTestApp creates a minimal App for unit tests in other packages that need
+// an App instance with a rate limiter but without a real MongoDB connection.
+// The injected store is used as-is; callers are responsible for configuring it.
+func NewTestApp(s store.Interface) *App {
+	return &App{
+		Store:       s,
+		rateLimiter: rate.NewLimiter(rate.Inf, 1),
+	}
 }

--- a/bot/utils_test.go
+++ b/bot/utils_test.go
@@ -1,0 +1,120 @@
+/* utils_test.go
+ * Unit tests for bot utility functions (singleElimField, elimPositionLabel,
+ * swissBucketField empty path, sendError error path).
+ */
+
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	format "pickems-bot/tournament"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// region elimPositionLabel tests
+
+func TestElimPositionLabel_Champion(t *testing.T) {
+	e := format.ElimPredictionEntry{Team: "Alpha", Round: "Grand Final", ToWin: true}
+	assert.Equal(t, "🏆 Champion", elimPositionLabel(e))
+}
+
+func TestElimPositionLabel_RunnerUp(t *testing.T) {
+	e := format.ElimPredictionEntry{Team: "Beta", Round: "Grand Final", ToWin: false}
+	assert.Equal(t, "🥈 Runner-up", elimPositionLabel(e))
+}
+
+func TestElimPositionLabel_ThirdFourth(t *testing.T) {
+	e := format.ElimPredictionEntry{Team: "Gamma", Round: "Semi Final", ToWin: false}
+	assert.Equal(t, "🥉 3rd / 4th", elimPositionLabel(e))
+}
+
+func TestElimPositionLabel_Top8(t *testing.T) {
+	e := format.ElimPredictionEntry{Team: "Delta", Round: "Quarter Final", ToWin: false}
+	assert.Equal(t, "🎖️ Top 8", elimPositionLabel(e))
+}
+
+func TestElimPositionLabel_DefaultRound(t *testing.T) {
+	e := format.ElimPredictionEntry{Team: "Epsilon", Round: "Best of 32", ToWin: false}
+	assert.Equal(t, "Best of 32", elimPositionLabel(e))
+}
+
+// endregion
+
+// region singleElimField tests
+
+func TestSingleElimField_SortsCorrectly(t *testing.T) {
+	entries := []format.ElimPredictionEntry{
+		{Team: "Beta", Round: "Semi Final", ToWin: false, Status: format.StatusFailed},
+		{Team: "Alpha", Round: "Grand Final", ToWin: true, Status: format.StatusSucceeded},
+		{Team: "Gamma", Round: "Quarter Final", ToWin: false, Status: format.StatusPending},
+	}
+
+	field := singleElimField(entries)
+	require.NotNil(t, field)
+	assert.Equal(t, "**Predictions**", field.Name)
+	// Champion (Grand Final winner) should appear first in the value string
+	assert.Contains(t, field.Value, "Alpha")
+	assert.Contains(t, field.Value, "🏆 Champion")
+}
+
+func TestSingleElimField_EmptyEntries_ShowsDash(t *testing.T) {
+	field := singleElimField(nil)
+	require.NotNil(t, field)
+	assert.Equal(t, "—", field.Value)
+}
+
+func TestSingleElimField_WithinSameRound_WinnerFirst(t *testing.T) {
+	// Two Grand Final entries: winner (ToWin=true) and runner-up (ToWin=false)
+	entries := []format.ElimPredictionEntry{
+		{Team: "RunnerUp", Round: "Grand Final", ToWin: false, Status: format.StatusFailed},
+		{Team: "Champion", Round: "Grand Final", ToWin: true, Status: format.StatusSucceeded},
+	}
+	field := singleElimField(entries)
+	require.NotNil(t, field)
+	// Champion (ToWin=true) must appear before Runner-up in the output
+	champIdx := strings.Index(field.Value, "🏆 Champion")
+	ruIdx := strings.Index(field.Value, "🥈 Runner-up")
+	assert.GreaterOrEqual(t, champIdx, 0, "champion label should be in the output")
+	assert.GreaterOrEqual(t, ruIdx, 0, "runner-up label should be in the output")
+	assert.Less(t, champIdx, ruIdx, "Champion should appear before Runner-up")
+}
+
+// endregion
+
+// region swissBucketField empty path test
+
+func TestSwissBucketField_EmptyEntries_ShowsDash(t *testing.T) {
+	field := swissBucketField("3-0 Picks", nil)
+	require.NotNil(t, field)
+	assert.Equal(t, "3-0 Picks", field.Name)
+	assert.Equal(t, "—", field.Value)
+}
+
+// endregion
+
+// region sendError error path test
+
+func TestSendError_LogsOnSessionError(t *testing.T) {
+	// When the session returns an error from ChannelMessageSendEmbed,
+	// sendError should not panic and should log the failure (no return value to assert).
+	session := &MockDiscordSession{ErrorToReturn: assert.AnError}
+	// Should not panic even when session.ChannelMessageSendEmbed returns an error
+	assert.NotPanics(t, func() {
+		sendError(session, "channel-123", "something went wrong")
+	})
+}
+
+func TestSendError_Success(t *testing.T) {
+	session := NewMockDiscordSession()
+	sendError(session, "channel-123", "test error message")
+	require.Len(t, session.SentEmbeds, 1)
+	assert.Equal(t, "Error", session.SentEmbeds[0].Embed.Title)
+	assert.Equal(t, "test error message", session.SentEmbeds[0].Embed.Description)
+	assert.Equal(t, red, session.SentEmbeds[0].Embed.Color)
+}
+
+// endregion

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -16,18 +17,6 @@ type Config struct {
 	Round          string `toml:"round"`
 	DataSource     string `toml:"data_source"` // liquipedia or pandascore
 
-	// Liquipedia only fields
-	Page   string `toml:"page"`   // liquipedia only
-	Params string `toml:"params"` // liquipedia only, optional
-	// Format overrides automatic format detection from match node sections.
-	// Leave empty to auto-detect (recommended for single-stage tournaments).
-	// Set explicitly (e.g. "single-elimination") when the Liquipedia page
-	// contains multiple stages and auto-detection would pick the wrong one.
-	Format string `toml:"format"` // liquipedia only
-
-	// Pandascore only fields
-	SeriesID int `toml:"series_id"` // PandaScore serie ID (note: API field is serie_id without 's')
-
 	// Bot modes
 	UpcomingOnly bool `toml:"upcoming_only"`
 	Test         bool `toml:"test"`
@@ -36,6 +25,27 @@ type Config struct {
 	// LogLevel controls the minimum log level emitted (debug, info, warn, error).
 	// Defaults to "info". When test=true and log_level is unset, defaults to "debug".
 	LogLevel string `toml:"log_level"`
+
+	Liquipedia LiquipediaConfig `toml:"liquipedia"`
+	PandaScore PandaScoreConfig `toml:"pandascore"`
+}
+
+// LiquipediaConfig holds Liquipedia-specific configuration fields.
+type LiquipediaConfig struct {
+	APIURL string `toml:"api_url"`
+	Page   string `toml:"page"`
+	Params string `toml:"params"`
+	// Format overrides automatic format detection from match node sections.
+	// Leave empty to auto-detect (recommended for single-stage tournaments).
+	// Set explicitly (e.g. "single-elimination") when the Liquipedia page
+	// contains multiple stages and auto-detection would pick the wrong one.
+	Format string `toml:"format"`
+}
+
+// PandaScoreConfig holds PandaScore-specific configuration fields.
+type PandaScoreConfig struct {
+	APIURL   string `toml:"api_url"`
+	SeriesID int    `toml:"series_id"` // PandaScore serie ID (note: API field is serie_id without 's')
 }
 
 // Load reads and validates a config.toml file at path.
@@ -51,12 +61,18 @@ func Load(path string) (Config, error) {
 
 	switch c.DataSource {
 	case "liquipedia":
-		if c.Page == "" {
-			return Config{}, fmt.Errorf("page is a required field for liquipedia as a datasource in %s", path)
+		if c.Liquipedia.Page == "" {
+			return Config{}, fmt.Errorf("liquipedia.page is a required field for liquipedia as a datasource in %s", path)
+		}
+		if strings.TrimSpace(c.Liquipedia.APIURL) == "" {
+			return Config{}, fmt.Errorf("liquipedia.api_url is a required field for liquipedia as a datasource in %s", path)
 		}
 	case "pandascore":
-		if c.SeriesID == 0 {
-			return Config{}, fmt.Errorf("series_id is a required field for pandascore as a datasource in %s", path)
+		if c.PandaScore.SeriesID == 0 {
+			return Config{}, fmt.Errorf("pandascore.series_id is a required field for pandascore as a datasource in %s", path)
+		}
+		if strings.TrimSpace(c.PandaScore.APIURL) == "" {
+			return Config{}, fmt.Errorf("pandascore.api_url is a required field for pandascore as a datasource in %s", path)
 		}
 	default:
 		return Config{}, fmt.Errorf("unsupported datasource in %s, allowed values are 'liquipedia' and 'pandascore'", path)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,17 +26,21 @@ func TestLoad_AllFields_Liquipedia(t *testing.T) {
 	path := writeTemp(t, `
 tournament_name = "MyEvent_2026"
 data_source = "liquipedia"
-page = "Foo/2026/Bar/Stage_1"
 round = "Stage_1"
 upcoming_only = true
 test = true
+
+[liquipedia]
+api_url = "https://api.liquipedia.net/api/v3/match"
+page = "Foo/2026/Bar/Stage_1"
 `)
 
 	cfg, err := Load(path)
 	assert.NoError(t, err)
 	assert.Equal(t, "MyEvent_2026", cfg.TournamentName)
 	assert.Equal(t, "liquipedia", cfg.DataSource)
-	assert.Equal(t, "Foo/2026/Bar/Stage_1", cfg.Page)
+	assert.Equal(t, "https://api.liquipedia.net/api/v3/match", cfg.Liquipedia.APIURL)
+	assert.Equal(t, "Foo/2026/Bar/Stage_1", cfg.Liquipedia.Page)
 	assert.Equal(t, "Stage_1", cfg.Round)
 	assert.True(t, cfg.UpcomingOnly)
 	assert.True(t, cfg.Test)
@@ -46,17 +50,21 @@ func TestLoad_AllFields_PandaScore(t *testing.T) {
 	path := writeTemp(t, `
 tournament_name = "MyEvent_2026"
 data_source = "pandascore"
-series_id = 10583
 round = "Stage_1"
 upcoming_only = true
 test = true
+
+[pandascore]
+api_url = "https://api.pandascore.co/csgo/matches"
+series_id = 10583
 `)
 
 	cfg, err := Load(path)
 	assert.NoError(t, err)
 	assert.Equal(t, "MyEvent_2026", cfg.TournamentName)
 	assert.Equal(t, "pandascore", cfg.DataSource)
-	assert.Equal(t, 10583, cfg.SeriesID)
+	assert.Equal(t, "https://api.pandascore.co/csgo/matches", cfg.PandaScore.APIURL)
+	assert.Equal(t, 10583, cfg.PandaScore.SeriesID)
 	assert.Equal(t, "Stage_1", cfg.Round)
 	assert.True(t, cfg.UpcomingOnly)
 	assert.True(t, cfg.Test)
@@ -66,8 +74,11 @@ func TestLoad_DefaultBoolsAndOptionalParams(t *testing.T) {
 	path := writeTemp(t, `
 tournament_name = "X"
 data_source = "liquipedia"
-page = "Y/Z"
 round = "Z"
+
+[liquipedia]
+api_url = "https://api.liquipedia.net/api/v3/match"
+page = "Y/Z"
 `)
 
 	cfg, err := Load(path)
@@ -79,8 +90,11 @@ round = "Z"
 func TestLoad_MissingTournamentName(t *testing.T) {
 	path := writeTemp(t, `
 data_source = "liquipedia"
-page = "Y/Z"
 round = "Z"
+
+[liquipedia]
+api_url = "https://api.liquipedia.net/api/v3/match"
+page = "Y/Z"
 `)
 
 	_, err := Load(path)
@@ -93,16 +107,37 @@ func TestLoad_MissingPage(t *testing.T) {
 tournament_name = "X"
 data_source = "liquipedia"
 round = "Z"
+
+[liquipedia]
+api_url = "https://api.liquipedia.net/api/v3/match"
 `)
 
 	_, err := Load(path)
 	assert.Error(t, err)
 }
 
+func TestLoad_MissingAPIURL_Liquipedia(t *testing.T) {
+	path := writeTemp(t, `
+tournament_name = "X"
+data_source = "liquipedia"
+round = "Z"
+
+[liquipedia]
+page = "Y/Z"
+`)
+
+	_, err := Load(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "api_url")
+}
+
 func TestLoad_MissingRound(t *testing.T) {
 	path := writeTemp(t, `
 tournament_name = "X"
 data_source = "liquipedia"
+
+[liquipedia]
+api_url = "https://api.liquipedia.net/api/v3/match"
 page = "Y/Z"
 `)
 
@@ -115,11 +150,29 @@ func TestLoad_MissingSeriesID(t *testing.T) {
 tournament_name = "X"
 data_source = "pandascore"
 round = "Z"
+
+[pandascore]
+api_url = "https://api.pandascore.co/csgo/matches"
 `)
 
 	_, err := Load(path)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "series_id")
+}
+
+func TestLoad_MissingAPIURL_PandaScore(t *testing.T) {
+	path := writeTemp(t, `
+tournament_name = "X"
+data_source = "pandascore"
+round = "Z"
+
+[pandascore]
+series_id = 12345
+`)
+
+	_, err := Load(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "api_url")
 }
 
 func TestLoad_UnsupportedDataSource(t *testing.T) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,10 @@ services:
     ports:
       - "8080:8080"
     restart: unless-stopped
+
+  test-server:
+    image: ghcr.io/zacharyab24/pickems-test-server:latest
+    ports:
+      - "8081:8081"
+    profiles:
+      - integration

--- a/main.go
+++ b/main.go
@@ -101,12 +101,12 @@ func main() {
 
 	switch cfg.DataSource {
 	case "pandascore":
-		poller := web.NewPoller(apiInstance, cfg.SeriesID, os.Getenv("PANDASCORE_API_KEY"), logger)
+		poller := web.NewPoller(apiInstance, cfg.PandaScore.SeriesID, os.Getenv("PANDASCORE_API_KEY"), cfg.PandaScore.APIURL, logger)
 		go poller.Start()
 		logger.Info("PandaScore poller started")
 	case "liquipedia":
 		go func() {
-			if err := web.Start(web.Config{Addr: ":8080", API: apiInstance, Page: cfg.Page, Logger: logger}); err != nil {
+			if err := web.Start(web.Config{Addr: ":8080", API: apiInstance, Page: cfg.Liquipedia.Page, Logger: logger}); err != nil {
 				logger.Error("web server exited", "error", err)
 				os.Exit(1)
 			}

--- a/scripts/configure/configure.go
+++ b/scripts/configure/configure.go
@@ -35,6 +35,11 @@ type tournamentConfig struct {
 	SeriesID int
 }
 
+const (
+	liquipediaProdAPIURL = "https://api.liquipedia.net/api/v3/match"
+	pandaScoreProdAPIURL = "https://api.pandascore.co/csgo/matches"
+)
+
 func fetchWikitext(path string) (string, error) {
 	req, err := http.NewRequest("GET", liquipediaBase+path+"?action=raw", nil)
 	if err != nil {
@@ -207,15 +212,30 @@ func writeConfig(path string, c tournamentConfig) error {
 	fmt.Fprintf(f, "round           = %q\n", c.Round)
 	fmt.Fprintf(f, "upcoming_only   = %t\n", c.UpcomingOnly)
 	fmt.Fprintf(f, "test            = %t\n", c.Test)
+	fmt.Fprintln(f, "log_level       = \"\"")
 	fmt.Fprintln(f)
-	switch c.DataSource {
-	case "liquipedia":
-		fmt.Fprintln(f, "# Liquipedia settings")
-		fmt.Fprintf(f, "page   = %q\n", c.Page)
-		fmt.Fprintf(f, "format = %q\n", c.Format)
-	case "pandascore":
-		fmt.Fprintln(f, "# PandaScore settings")
-		fmt.Fprintf(f, "series_id = %d\n", c.SeriesID)
+
+	// Liquipedia section — always written; api_url uses the production URL when
+	// liquipedia is the active source, empty string otherwise.
+	liqAPIURL := ""
+	if c.DataSource == "liquipedia" {
+		liqAPIURL = liquipediaProdAPIURL
 	}
+	fmt.Fprintln(f, "[liquipedia]")
+	fmt.Fprintf(f, "api_url = %q\n", liqAPIURL)
+	fmt.Fprintf(f, "page    = %q\n", c.Page)
+	fmt.Fprintf(f, "params  = \"\"\n")
+	fmt.Fprintf(f, "format  = %q\n", c.Format)
+	fmt.Fprintln(f)
+
+	// PandaScore section — always written; api_url uses the production URL when
+	// pandascore is the active source, empty string otherwise.
+	psAPIURL := ""
+	if c.DataSource == "pandascore" {
+		psAPIURL = pandaScoreProdAPIURL
+	}
+	fmt.Fprintln(f, "[pandascore]")
+	fmt.Fprintf(f, "api_url   = %q\n", psAPIURL)
+	fmt.Fprintf(f, "series_id = %d\n", c.SeriesID)
 	return nil
 }

--- a/scripts/configure/main_test.go
+++ b/scripts/configure/main_test.go
@@ -234,9 +234,15 @@ func TestWriteConfig_Liquipedia(t *testing.T) {
 	assert.Contains(t, out, `tournament_name = "Foo_2026"`)
 	assert.Contains(t, out, `round           = "Stage_1"`)
 	assert.Contains(t, out, `upcoming_only   = false`)
-	assert.Contains(t, out, `page   = "Foo/2026/Bar/Stage_1"`)
-	assert.Contains(t, out, `format = "swiss"`)
-	assert.NotContains(t, out, "series_id")
+	// Nested liquipedia section
+	assert.Contains(t, out, "[liquipedia]")
+	assert.Contains(t, out, `api_url = "https://api.liquipedia.net/api/v3/match"`)
+	assert.Contains(t, out, `page    = "Foo/2026/Bar/Stage_1"`)
+	assert.Contains(t, out, `format  = "swiss"`)
+	// PandaScore section always written, but api_url is blank when not the active source
+	assert.Contains(t, out, "[pandascore]")
+	assert.Contains(t, out, `api_url   = ""`)
+	assert.Contains(t, out, "series_id = 0")
 }
 
 func TestWriteConfig_PandaScore(t *testing.T) {
@@ -260,9 +266,13 @@ func TestWriteConfig_PandaScore(t *testing.T) {
 	assert.Contains(t, out, `data_source     = "pandascore"`)
 	assert.Contains(t, out, `tournament_name = "IEM_Cologne_2026"`)
 	assert.Contains(t, out, `round           = "Stage_1"`)
-	assert.Contains(t, out, `series_id = 10488`)
-	assert.NotContains(t, out, "page")
-	assert.NotContains(t, out, "format")
+	// Nested pandascore section
+	assert.Contains(t, out, "[pandascore]")
+	assert.Contains(t, out, `api_url   = "https://api.pandascore.co/csgo/matches"`)
+	assert.Contains(t, out, "series_id = 10488")
+	// Liquipedia section always written, but api_url is blank when not the active source
+	assert.Contains(t, out, "[liquipedia]")
+	assert.Contains(t, out, `api_url = ""`)
 }
 
 func TestWriteConfig_BadPath(t *testing.T) {

--- a/scripts/fetchtest/main.go
+++ b/scripts/fetchtest/main.go
@@ -47,7 +47,7 @@ func main() {
 		if apiKey == "" {
 			log.Fatal("LIQUIDPEDIADB_API_KEY not set")
 		}
-		fetcher = store.NewLiquipediaFetcher(apiKey, arg)
+		fetcher = store.NewLiquipediaFetcher("https://api.liquipedia.net/api/v3/match", apiKey, arg)
 
 	case "pandascore":
 		apiKey := os.Getenv("PANDASCORE_API_KEY")
@@ -58,7 +58,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("seriesID must be an integer, got %q", arg)
 		}
-		fetcher = store.NewPandaScoreFetcher(apiKey, seriesID)
+		fetcher = store.NewPandaScoreFetcher("https://api.pandascore.co/csgo/matches", apiKey, seriesID)
 
 	default:
 		log.Fatalf("unknown source %q — use 'liquipedia' or 'pandascore'", source)

--- a/sources/http_test.go
+++ b/sources/http_test.go
@@ -1,0 +1,157 @@
+/* http_test.go
+ * Unit tests for the HTTP client functions in the sources package.
+ * Uses httptest.Server to avoid real network calls.
+ */
+
+package sources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// region GetPandaScoreMatches tests
+
+func TestGetPandaScoreMatches_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		// Verify query params were set
+		assert.Equal(t, "99001", r.URL.Query().Get("filter[serie_id]"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id": 1, "name": "Round 1", "status": "not_started", "opponents": [], "winner": null, "results": []}]`))
+	}))
+	defer srv.Close()
+
+	body, err := GetPandaScoreMatches(srv.URL, "test-key", 99001)
+	require.NoError(t, err)
+	assert.Contains(t, body, "not_started")
+}
+
+func TestGetPandaScoreMatches_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := GetPandaScoreMatches(srv.URL, "bad-key", 99001)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnrecoverable)
+}
+
+func TestGetPandaScoreMatches_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := GetPandaScoreMatches(srv.URL, "key", 99001)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnrecoverable)
+}
+
+func TestGetPandaScoreMatches_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := GetPandaScoreMatches(srv.URL, "key", 99001)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnrecoverable)
+}
+
+func TestGetPandaScoreMatches_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := GetPandaScoreMatches(srv.URL, "key", 99001)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrUnrecoverable) // 500 is retriable, not unrecoverable
+	assert.Contains(t, err.Error(), "unexpected status code")
+}
+
+func TestGetPandaScoreMatches_InvalidURL(t *testing.T) {
+	_, err := GetPandaScoreMatches("://invalid-url", "key", 1)
+	require.Error(t, err)
+}
+
+// endregion
+
+// region GetLiquipediaMatchDataByPage tests
+
+func TestGetLiquipediaMatchDataByPage_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Authorization"), "Apikey test-key")
+		// Verify query params
+		assert.Equal(t, "counterstrike", r.URL.Query().Get("wiki"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result": []}`))
+	}))
+	defer srv.Close()
+
+	body, err := GetLiquipediaMatchDataByPage(srv.URL, "test-key", "Test/Page")
+	require.NoError(t, err)
+	assert.Contains(t, body, "result")
+}
+
+func TestGetLiquipediaMatchDataByPage_NonOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := GetLiquipediaMatchDataByPage(srv.URL, "key", "Test/Page")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "429")
+}
+
+func TestGetLiquipediaMatchDataByPage_InvalidURL(t *testing.T) {
+	_, err := GetLiquipediaMatchDataByPage("://bad-url", "key", "page")
+	require.Error(t, err)
+}
+
+// endregion
+
+// region GetLiquipediaMatchData tests
+
+func TestGetLiquipediaMatchData_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Authorization"), "Apikey test-key")
+		// Verify the conditions query param contains bracket IDs
+		cond := r.URL.Query().Get("conditions")
+		assert.Contains(t, cond, "ID1")
+		assert.Contains(t, cond, "ID2")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result": []}`))
+	}))
+	defer srv.Close()
+
+	body, err := GetLiquipediaMatchData(srv.URL, "test-key", []string{"ID1", "ID2"})
+	require.NoError(t, err)
+	assert.Contains(t, body, "result")
+}
+
+func TestGetLiquipediaMatchData_NonOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := GetLiquipediaMatchData(srv.URL, "key", []string{"ID1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status code")
+}
+
+func TestGetLiquipediaMatchData_InvalidURL(t *testing.T) {
+	_, err := GetLiquipediaMatchData("://bad-url", "key", []string{"ID1"})
+	require.Error(t, err)
+}
+
+// endregion

--- a/sources/liquipedia.go
+++ b/sources/liquipedia.go
@@ -25,9 +25,7 @@ import (
 //
 // Preconditions: valid API key, pagename is a slash-separated Liquipedia path
 // Postconditions: returns raw JSON string or an error
-func GetLiquipediaMatchDataByPage(apiKey string, pagename string) (string, error) {
-	apiURL := "https://api.liquipedia.net/api/v3/match"
-
+func GetLiquipediaMatchDataByPage(apiURL string, apiKey string, pagename string) (string, error) {
 	parsedURL, err := url.Parse(apiURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid api url: %w", err)
@@ -69,9 +67,7 @@ func GetLiquipediaMatchDataByPage(apiKey string, pagename string) (string, error
 
 // GetLiquipediaMatchData fetches match data from the LiquipediaDB API filtered by match2bracketid.
 // Each match2bracketid corresponds to a bracket table on a tournament page.
-func GetLiquipediaMatchData(apiKey string, bracketIds []string) (string, error) {
-	apiURL := "https://api.liquipedia.net/api/v3/match"
-
+func GetLiquipediaMatchData(apiURL string, apiKey string, bracketIds []string) (string, error) {
 	var conditions []string
 	for _, id := range bracketIds {
 		conditions = append(conditions, fmt.Sprintf("[[match2bracketid::%s]]", id))

--- a/sources/liquipedia_integration_test.go
+++ b/sources/liquipedia_integration_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package sources_test
+
+import (
+	"testing"
+
+	"pickems-bot/sources"
+	"pickems-bot/testhelpers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	liqURL     = testhelpers.TestServerBase + "/liquipedia/api/v3/match"
+	liqTestKey = "pickems-test-key"
+	liqPage    = "Test/Tournament/2026"
+)
+
+// TestLiquipedia_GetMatches_Ongoing verifies that the ongoing state returns
+// a non-empty list of well-formed matches.
+func TestLiquipedia_GetMatches_Ongoing(t *testing.T) {
+	testhelpers.SetState(t, "liquipedia", "ongoing")
+
+	raw, err := sources.GetLiquipediaMatchDataByPage(liqURL, liqTestKey, liqPage)
+	require.NoError(t, err)
+
+	nodes, err := sources.ParseLiquipediaMatches(raw)
+	require.NoError(t, err)
+	assert.NotEmpty(t, nodes, "expected matches in ongoing state")
+
+	for _, n := range nodes {
+		assert.NotEmpty(t, n.ID)
+		assert.NotEmpty(t, n.Team1)
+		assert.NotEmpty(t, n.Team2)
+	}
+}
+
+// TestLiquipedia_GetMatches_NotStarted verifies that the not_started state
+// returns an empty result set without an error (bot must not crash).
+func TestLiquipedia_GetMatches_NotStarted(t *testing.T) {
+	testhelpers.SetState(t, "liquipedia", "not_started")
+
+	raw, err := sources.GetLiquipediaMatchDataByPage(liqURL, liqTestKey, liqPage)
+	require.NoError(t, err)
+
+	nodes, err := sources.ParseLiquipediaMatches(raw)
+	require.NoError(t, err)
+	assert.Empty(t, nodes, "expected empty match list in not_started state")
+}
+
+// TestLiquipedia_GetMatches_WrongKey verifies that a bad API key returns an
+// error (403 from the test server).
+func TestLiquipedia_GetMatches_WrongKey(t *testing.T) {
+	testhelpers.SetState(t, "liquipedia", "ongoing")
+
+	_, err := sources.GetLiquipediaMatchDataByPage(liqURL, "wrong-key", liqPage)
+	require.Error(t, err, "expected error for bad API key")
+}

--- a/sources/pandascore.go
+++ b/sources/pandascore.go
@@ -18,9 +18,7 @@ var ErrUnrecoverable = errors.New("unrecoverable api error")
 
 // GetPandaScoreMatches fetches all matches for a given series from the PandaScore API.
 // Returns the raw JSON response body as a string.
-func GetPandaScoreMatches(apiKey string, seriesID int) (string, error) {
-	apiURL := "https://api.pandascore.co/csgo/matches"
-
+func GetPandaScoreMatches(apiURL string, apiKey string, seriesID int) (string, error) {
 	parsedURL, err := url.Parse(apiURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid url: %w", err)

--- a/sources/pandascore_integration_test.go
+++ b/sources/pandascore_integration_test.go
@@ -1,0 +1,103 @@
+//go:build integration
+
+package sources_test
+
+import (
+	"errors"
+	"testing"
+
+	"pickems-bot/sources"
+	"pickems-bot/testhelpers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	psURL      = testhelpers.TestServerBase + "/pandascore/csgo/matches"
+	psTestKey  = "pickems-test-key"
+	psSeriesID = 99001
+)
+
+// TestPandaScore_GetMatches_Ongoing verifies that the ongoing state returns
+// a non-empty list of well-formed matches.
+func TestPandaScore_GetMatches_Ongoing(t *testing.T) {
+	testhelpers.SetState(t, "pandascore", "ongoing")
+
+	raw, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	require.NoError(t, err)
+
+	nodes, err := sources.ParsePandaScoreMatches(raw)
+	require.NoError(t, err)
+	assert.NotEmpty(t, nodes, "expected matches in ongoing state")
+
+	for _, n := range nodes {
+		assert.NotEmpty(t, n.ID)
+		assert.NotEmpty(t, n.Team1)
+		assert.NotEmpty(t, n.Team2)
+	}
+}
+
+// TestPandaScore_GetMatches_NotStarted verifies that the not_started state
+// returns an empty list without an error (the bot must not crash).
+func TestPandaScore_GetMatches_NotStarted(t *testing.T) {
+	testhelpers.SetState(t, "pandascore", "not_started")
+
+	raw, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	require.NoError(t, err)
+
+	nodes, err := sources.ParsePandaScoreMatches(raw)
+	require.NoError(t, err)
+	assert.Empty(t, nodes, "expected empty match list in not_started state")
+}
+
+// TestPandaScore_GetMatches_WrongKey verifies that a bad API key causes an
+// ErrUnrecoverable error (401 from the test server).
+func TestPandaScore_GetMatches_WrongKey(t *testing.T) {
+	testhelpers.SetState(t, "pandascore", "ongoing")
+
+	_, err := sources.GetPandaScoreMatches(psURL, "wrong-key", psSeriesID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sources.ErrUnrecoverable),
+		"expected ErrUnrecoverable for bad API key, got: %v", err)
+}
+
+// TestPandaScore_GetMatches_NotFound verifies that an unknown series ID causes
+// an ErrUnrecoverable error (404 from the test server).
+func TestPandaScore_GetMatches_NotFound(t *testing.T) {
+	// The test server returns 404 when filter[serie_id] is present but not "99001".
+	// Use any other value to trigger this.
+	_, err := sources.GetPandaScoreMatches(psURL, psTestKey, 12345)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sources.ErrUnrecoverable),
+		"expected ErrUnrecoverable for unknown series ID, got: %v", err)
+}
+
+// TestPandaScore_Complete_HasMoreFinished verifies that the complete state has
+// at least one more finished match than the ongoing state.
+func TestPandaScore_Complete_HasMoreFinished(t *testing.T) {
+	testhelpers.SetState(t, "pandascore", "ongoing")
+	rawOngoing, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	require.NoError(t, err)
+	ongoingNodes, err := sources.ParsePandaScoreMatches(rawOngoing)
+	require.NoError(t, err)
+
+	testhelpers.SetState(t, "pandascore", "complete")
+	rawComplete, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	require.NoError(t, err)
+	completeNodes, err := sources.ParsePandaScoreMatches(rawComplete)
+	require.NoError(t, err)
+
+	countFinished := func(nodes []sources.MatchNode) int {
+		n := 0
+		for _, m := range nodes {
+			if m.Status == "finished" {
+				n++
+			}
+		}
+		return n
+	}
+
+	assert.Greater(t, countFinished(completeNodes), countFinished(ongoingNodes),
+		"complete state should have more finished matches than ongoing")
+}

--- a/store/datasource.go
+++ b/store/datasource.go
@@ -13,24 +13,26 @@ type DataSourceFetcher interface {
 
 // LiquipediaFetcher implements the DataSourceFetcher interface
 type LiquipediaFetcher struct {
+	apiURL string
 	apiKey string
 	page   string
 }
 
 // PandaScoreFetcher implements the DataSourceFetcher interface
 type PandaScoreFetcher struct {
+	apiURL   string
 	apiKey   string
 	seriesID int
 }
 
-// NewLiquipediaFetcher creates a LiquipediaFetcher with the given API key and page path.
-func NewLiquipediaFetcher(apiKey, page string) LiquipediaFetcher {
-	return LiquipediaFetcher{apiKey: apiKey, page: page}
+// NewLiquipediaFetcher creates a LiquipediaFetcher with the given API URL, API key and page path.
+func NewLiquipediaFetcher(apiURL, apiKey, page string) LiquipediaFetcher {
+	return LiquipediaFetcher{apiURL: apiURL, apiKey: apiKey, page: page}
 }
 
 // FetchMatchData fetches match data using liquipedia as a datasource, filtered to the current round of a tournament
 func (f LiquipediaFetcher) FetchMatchData(round string) (tournament.MatchResult, []sources.MatchNode, error) {
-	matchData, err := sources.GetLiquipediaMatchDataByPage(f.apiKey, f.page)
+	matchData, err := sources.GetLiquipediaMatchDataByPage(f.apiURL, f.apiKey, f.page)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -63,21 +65,21 @@ func (f LiquipediaFetcher) FetchMatchData(round string) (tournament.MatchResult,
 // FetchSchedule fetches the scheduled matches for the tournament using Liquipedia as a datasource.
 // Doesn't do any filtering, callers are responsible for filtering by round / time / etc
 func (f LiquipediaFetcher) FetchSchedule() ([]sources.ScheduledMatch, error) {
-	matchData, err := sources.GetLiquipediaMatchDataByPage(f.apiKey, f.page)
+	matchData, err := sources.GetLiquipediaMatchDataByPage(f.apiURL, f.apiKey, f.page)
 	if err != nil {
 		return nil, err
 	}
 	return sources.ParseLiquipediaSchedule(matchData)
 }
 
-// NewPandaScoreFetcher creates a PandaScoreFetcher with the given API key and series ID.
-func NewPandaScoreFetcher(apiKey string, seriesID int) PandaScoreFetcher {
-	return PandaScoreFetcher{apiKey: apiKey, seriesID: seriesID}
+// NewPandaScoreFetcher creates a PandaScoreFetcher with the given API URL, API key and series ID.
+func NewPandaScoreFetcher(apiURL string, apiKey string, seriesID int) PandaScoreFetcher {
+	return PandaScoreFetcher{apiURL: apiURL, apiKey: apiKey, seriesID: seriesID}
 }
 
 // FetchMatchData fetches match data using PandaSource as a datasource, filtered to the current round of a tournament
 func (f PandaScoreFetcher) FetchMatchData(round string) (tournament.MatchResult, []sources.MatchNode, error) {
-	matchData, err := sources.GetPandaScoreMatches(f.apiKey, f.seriesID)
+	matchData, err := sources.GetPandaScoreMatches(f.apiURL, f.apiKey, f.seriesID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,7 +112,7 @@ func (f PandaScoreFetcher) FetchMatchData(round string) (tournament.MatchResult,
 // FetchSchedule fetches the scheduled matches for the tournament using PandaScore as a datasource.
 // Doesn't do any filtering, callers are responsible for filtering by round / time / etc
 func (f PandaScoreFetcher) FetchSchedule() ([]sources.ScheduledMatch, error) {
-	matchData, err := sources.GetPandaScoreMatches(f.apiKey, f.seriesID)
+	matchData, err := sources.GetPandaScoreMatches(f.apiURL, f.apiKey, f.seriesID)
 	if err != nil {
 		return nil, err
 	}

--- a/store/datasource_test.go
+++ b/store/datasource_test.go
@@ -1,0 +1,191 @@
+/* datasource_test.go
+ * Unit tests for LiquipediaFetcher and PandaScoreFetcher using httptest servers.
+ */
+
+package store
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Minimal Liquipedia JSON for a single Swiss-format match node.
+// Section must contain "round" so DetectKindFromMatchNodes identifies Swiss format.
+const liqSwissJSON = `{
+  "result": [
+    {
+      "match2id": "TEST_R01-M001",
+      "finished": 0,
+      "match2opponents": [{"name": "Alpha"}, {"name": "Beta"}],
+      "section": "Round 1",
+      "bestof": 3
+    }
+  ]
+}`
+
+// Minimal Liquipedia schedule JSON (one upcoming match).
+const liqScheduleJSON = `{
+  "result": [
+    {
+      "finished": 0,
+      "date": "2025-01-15 14:00:00",
+      "stream": {"twitch": "eslcs"},
+      "bestof": 3,
+      "match2opponents": [{"name": "Alpha"}, {"name": "Beta"}]
+    }
+  ]
+}`
+
+// Minimal PandaScore JSON for a single Swiss-format match node.
+// Name must contain "Round" so DetectKindFromMatchNodes (via Section field) identifies Swiss.
+const psMatchJSON = `[
+  {
+    "id": 1,
+    "name": "Round 1",
+    "status": "not_started",
+    "opponents": [
+      {"opponent": {"name": "Alpha", "id": 1}},
+      {"opponent": {"name": "Beta",  "id": 2}}
+    ],
+    "winner": null,
+    "results": []
+  }
+]`
+
+// Minimal PandaScore schedule JSON.
+const psScheduleJSON = `[
+  {
+    "status": "not_started",
+    "scheduled_at": "2025-01-15T14:00:00Z",
+    "number_of_games": 3,
+    "opponents": [
+      {"opponent": {"name": "Alpha"}},
+      {"opponent": {"name": "Beta"}}
+    ],
+    "streams_list": []
+  }
+]`
+
+// region NewPandaScoreFetcher tests
+
+func TestNewPandaScoreFetcher_Fields(t *testing.T) {
+	f := NewPandaScoreFetcher("http://example.com", "my-key", 42)
+	assert.Equal(t, "http://example.com", f.apiURL)
+	assert.Equal(t, "my-key", f.apiKey)
+	assert.Equal(t, 42, f.seriesID)
+}
+
+// endregion
+
+// region LiquipediaFetcher tests
+
+func TestLiquipediaFetcher_FetchMatchData_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(liqSwissJSON))
+	}))
+	defer srv.Close()
+
+	f := NewLiquipediaFetcher(srv.URL, "test-key", "Test/Page")
+	result, nodes, err := f.FetchMatchData("Round 1")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotEmpty(t, nodes)
+}
+
+func TestLiquipediaFetcher_FetchMatchData_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := NewLiquipediaFetcher(srv.URL, "key", "Test/Page")
+	_, _, err := f.FetchMatchData("Round 1")
+	require.Error(t, err)
+}
+
+func TestLiquipediaFetcher_FetchSchedule_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(liqScheduleJSON))
+	}))
+	defer srv.Close()
+
+	f := NewLiquipediaFetcher(srv.URL, "test-key", "Test/Page")
+	matches, err := f.FetchSchedule()
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "Alpha", matches[0].Team1)
+	assert.Equal(t, "Beta", matches[0].Team2)
+}
+
+func TestLiquipediaFetcher_FetchSchedule_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	f := NewLiquipediaFetcher(srv.URL, "key", "Test/Page")
+	_, err := f.FetchSchedule()
+	require.Error(t, err)
+}
+
+// endregion
+
+// region PandaScoreFetcher tests
+
+func TestPandaScoreFetcher_FetchMatchData_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(psMatchJSON))
+	}))
+	defer srv.Close()
+
+	f := NewPandaScoreFetcher(srv.URL, "test-key", 99001)
+	result, nodes, err := f.FetchMatchData("Round 1")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotEmpty(t, nodes)
+}
+
+func TestPandaScoreFetcher_FetchMatchData_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	f := NewPandaScoreFetcher(srv.URL, "key", 99001)
+	_, _, err := f.FetchMatchData("Round 1")
+	require.Error(t, err)
+}
+
+func TestPandaScoreFetcher_FetchSchedule_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(psScheduleJSON))
+	}))
+	defer srv.Close()
+
+	f := NewPandaScoreFetcher(srv.URL, "test-key", 99001)
+	matches, err := f.FetchSchedule()
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "Alpha", matches[0].Team1)
+}
+
+func TestPandaScoreFetcher_FetchSchedule_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	f := NewPandaScoreFetcher(srv.URL, "key", 99001)
+	_, err := f.FetchSchedule()
+	require.Error(t, err)
+}
+
+// endregion

--- a/store/test_helpers.go
+++ b/store/test_helpers.go
@@ -20,7 +20,7 @@ import (
 // NewMockStore creates a Store instance for testing purposes.
 // This can be used with a real test database or in-memory MongoDB.
 func NewMockStore(dbName string, mongoURI string) (*Store, error) {
-	return NewStore(dbName, mongoURI, "test_round", NewLiquipediaFetcher("", "Test/Tournament/2025"), nil)
+	return NewStore(dbName, mongoURI, "test_round", NewLiquipediaFetcher("", "", "Test/Tournament/2025"), nil)
 }
 
 // CreateTestStore creates a Store connected to a test database.

--- a/testdata/integration_config.toml
+++ b/testdata/integration_config.toml
@@ -1,0 +1,19 @@
+# Integration test config. Assumes the test server is running on localhost:8081.
+# Run with: go test -tags integration ./...
+
+data_source     = "pandascore"
+tournament_name = "Test_Tournament"
+round           = "Playoffs"
+upcoming_only   = false
+test            = true
+log_level       = "debug"
+
+[liquipedia]
+api_url = "http://localhost:8081/liquipedia/api/v3/match"
+page    = "Test/Tournament/2026"
+params  = ""
+format  = ""
+
+[pandascore]
+api_url   = "http://localhost:8081/pandascore/csgo/matches"
+series_id = 99001

--- a/testhelpers/integration.go
+++ b/testhelpers/integration.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+// Package testhelpers provides shared utilities for integration tests.
+// All helpers in this package require the test server to be running on
+// http://localhost:8081 before any integration test is invoked.
+package testhelpers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const TestServerBase = "http://localhost:8081"
+
+// SetState calls the test-control endpoint to change what the mock data
+// endpoint for the given source returns.
+//
+// source: "liquipedia" or "pandascore"
+// state:  "not_started" | "ongoing" | "complete"
+func SetState(t *testing.T, source, state string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"source":%q,"state":%q}`, source, state)
+	resp, err := http.Post(
+		TestServerBase+"/test/state",
+		"application/json",
+		strings.NewReader(body),
+	)
+	require.NoError(t, err, "SetState: HTTP request failed")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"SetState: expected 200 from /test/state, got %d", resp.StatusCode)
+}
+
+// MongoURI returns the MongoDB URI for integration tests. It checks
+// MONGO_TEST_URI first, then MONGO_PROD_URI (the same URI the bot uses in
+// production — the name is misleading; both environments share one cluster).
+// If neither is set, or the server is not reachable within 2 seconds, the test
+// is skipped.
+func MongoURI(t *testing.T) string {
+	t.Helper()
+	uri := os.Getenv("MONGO_TEST_URI")
+	if uri == "" {
+		uri = os.Getenv("MONGO_PROD_URI")
+	}
+	if uri == "" {
+		t.Skip("skipping: neither MONGO_TEST_URI nor MONGO_PROD_URI is set")
+	}
+
+	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(uri))
+	if err != nil {
+		t.Skipf("skipping: could not build mongo client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(context.Background())
+		t.Skipf("skipping: MongoDB not reachable at %s: %v", uri, err)
+	}
+	_ = client.Disconnect(context.Background())
+	return uri
+}
+
+// FireCallback asks the test server to POST a Liquipedia webhook payload to
+// callbackURL after delay seconds. Returns immediately (server responds 202).
+//
+// page must match the page configured in the bot's test config so the webhook
+// handler does not filter it out.
+func FireCallback(t *testing.T, callbackURL string, delay int, page string) {
+	t.Helper()
+	payload := fmt.Sprintf(`{
+		"callback_url": %q,
+		"delay": %d,
+		"payload": {"wiki":"counterstrike","page":%q,"event":"match_update"}
+	}`, callbackURL, delay, page)
+	resp, err := http.Post(
+		TestServerBase+"/test/fire-callback",
+		"application/json",
+		strings.NewReader(payload),
+	)
+	require.NoError(t, err, "FireCallback: HTTP request failed")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode,
+		"FireCallback: expected 202 from /test/fire-callback, got %d", resp.StatusCode)
+}

--- a/tournament/getters_test.go
+++ b/tournament/getters_test.go
@@ -1,0 +1,236 @@
+/* getters_test.go
+ * Tests for getter methods and simple functions across Swiss and SingleElim formats.
+ */
+
+package tournament
+
+import (
+	"fmt"
+	"testing"
+
+	"pickems-bot/models"
+	"pickems-bot/sources"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// region BucketStatus.String
+
+func TestBucketStatus_String_AllValues(t *testing.T) {
+	cases := []struct {
+		status BucketStatus
+		want   string
+	}{
+		{StatusSucceeded, "✅"},
+		{StatusPending, "⏳"},
+		{StatusFailed, "❌"},
+		{BucketStatus(99), "❓"}, // unknown value → fallback
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.status.String(), "BucketStatus(%d).String()", c.status)
+	}
+}
+
+// endregion
+
+// region SwissReport methods
+
+func TestSwissReport_FormatKind(t *testing.T) {
+	r := SwissReport{}
+	assert.Equal(t, Swiss, r.FormatKind())
+}
+
+func TestSwissReport_GetScore(t *testing.T) {
+	r := SwissReport{Score: models.ScoreResult{Successes: 3, Pending: 1, Failed: 2}}
+	s := r.GetScore()
+	assert.Equal(t, 3, s.Successes)
+	assert.Equal(t, 1, s.Pending)
+	assert.Equal(t, 2, s.Failed)
+}
+
+// endregion
+
+// region SwissResult methods
+
+func TestSwissResult_GetType(t *testing.T) {
+	r := SwissResult{}
+	assert.Equal(t, Swiss, r.GetType())
+}
+
+func TestSwissResult_GetRound(t *testing.T) {
+	r := SwissResult{Round: "Stage 1"}
+	assert.Equal(t, "Stage 1", r.GetRound())
+}
+
+func TestSwissResult_GetTeamNames(t *testing.T) {
+	r := SwissResult{Teams: map[string]string{"Alpha": "3-0", "Beta": "2-1"}}
+	names := r.GetTeamNames()
+	assert.Len(t, names, 2)
+	assert.Contains(t, names, "Alpha")
+	assert.Contains(t, names, "Beta")
+}
+
+// endregion
+
+// region swissFormat.GeneratePrediction / BuildFromMatchNodes / DecodeBSON
+
+func TestSwissFormat_GeneratePrediction(t *testing.T) {
+	user := models.User{UserID: "u1", Username: "alice"}
+	// 10 teams for a 16-team Swiss (5×16/8 = 10)
+	teams := make([]string, 10)
+	for i := range teams {
+		teams[i] = fmt.Sprintf("team%d", i)
+	}
+	p, err := swissFormat{}.GeneratePrediction(user, "Round 1", teams)
+	require.NoError(t, err)
+	assert.Equal(t, "u1", p.UserID)
+	assert.Equal(t, "alice", p.Username)
+	assert.Equal(t, "swiss", p.Format)
+	assert.Equal(t, "Round 1", p.Round)
+	assert.Len(t, p.Win, 2)     // 10/5 = 2
+	assert.Len(t, p.Advance, 6) // 3×2 = 6
+	assert.Len(t, p.Lose, 2)    // 10/5 = 2
+}
+
+func TestSwissFormat_BuildFromMatchNodes_Success(t *testing.T) {
+	nodes := []sources.MatchNode{
+		{Team1: "A", Team2: "B", Winner: "A", Section: "Round 1"},
+		{Team1: "C", Team2: "D", Winner: "C", Section: "Round 1"},
+	}
+	result, err := swissFormat{}.BuildFromMatchNodes(nodes, "Stage 1")
+	require.NoError(t, err)
+	sr, ok := result.(SwissResult)
+	require.True(t, ok)
+	assert.Equal(t, "Stage 1", sr.Round)
+	assert.Equal(t, "1-0", sr.Teams["A"])
+	assert.Equal(t, "0-1", sr.Teams["B"])
+}
+
+func TestSwissFormat_DecodeBSON_RoundTrip(t *testing.T) {
+	original := SwissResult{
+		Round: "Stage 2",
+		Teams: map[string]string{"Alpha": "2-1", "Beta": "1-2"},
+	}
+	raw, err := bson.Marshal(original)
+	require.NoError(t, err)
+
+	decoded, err := swissFormat{}.DecodeBSON(raw)
+	require.NoError(t, err)
+	sr, ok := decoded.(SwissResult)
+	require.True(t, ok)
+	assert.Equal(t, "Stage 2", sr.Round)
+	assert.Equal(t, "2-1", sr.Teams["Alpha"])
+}
+
+func TestSwissFormat_DecodeBSON_InvalidBytes(t *testing.T) {
+	_, err := swissFormat{}.DecodeBSON([]byte("not valid bson data!!"))
+	assert.Error(t, err)
+}
+
+// endregion
+
+// region SingleElimReport methods
+
+func TestSingleElimReport_FormatKind(t *testing.T) {
+	r := SingleElimReport{}
+	assert.Equal(t, SingleElim, r.FormatKind())
+}
+
+func TestSingleElimReport_GetScore(t *testing.T) {
+	r := SingleElimReport{Score: models.ScoreResult{Successes: 2, Pending: 0, Failed: 1}}
+	s := r.GetScore()
+	assert.Equal(t, 2, s.Successes)
+	assert.Equal(t, 0, s.Pending)
+	assert.Equal(t, 1, s.Failed)
+}
+
+// endregion
+
+// region EliminationResult methods
+
+func TestEliminationResult_GetType(t *testing.T) {
+	r := EliminationResult{}
+	assert.Equal(t, SingleElim, r.GetType())
+}
+
+func TestEliminationResult_GetRound(t *testing.T) {
+	r := EliminationResult{Round: "Playoffs"}
+	assert.Equal(t, "Playoffs", r.GetRound())
+}
+
+func TestEliminationResult_GetTeamNames(t *testing.T) {
+	r := EliminationResult{Teams: map[string]models.TeamProgress{
+		"Alpha": {Round: "Grand Final", Status: "advanced"},
+		"Beta":  {Round: "Semi Final", Status: "eliminated"},
+	}}
+	names := r.GetTeamNames()
+	assert.Len(t, names, 2)
+	assert.Contains(t, names, "Alpha")
+	assert.Contains(t, names, "Beta")
+}
+
+// endregion
+
+// region singleElimFormat.GeneratePrediction / BuildFromMatchNodes / DecodeBSON
+
+func TestSingleElimFormat_GeneratePrediction(t *testing.T) {
+	user := models.User{UserID: "u2", Username: "bob"}
+	// 4 teams → last-to-first: predicted champion + semi runners + quarter etc.
+	teams := []string{"T1", "T2", "T3", "T4"}
+	p, err := singleElimFormat{}.GeneratePrediction(user, "Playoffs", teams)
+	require.NoError(t, err)
+	assert.Equal(t, "u2", p.UserID)
+	assert.Equal(t, "single-elimination", p.Format)
+	assert.Equal(t, "Playoffs", p.Round)
+	assert.NotEmpty(t, p.Progression)
+	// 4 teams → 4 entries in progression map
+	assert.Len(t, p.Progression, 4)
+}
+
+func TestSingleElimFormat_BuildFromMatchNodes_Success(t *testing.T) {
+	// 3-match bracket: 2 semi-finals then 1 grand final
+	nodes := []sources.MatchNode{
+		{ID: "BR_R01-M001", Team1: "A", Team2: "B", Winner: "A", Section: "Bracket/4"},
+		{ID: "BR_R01-M002", Team1: "C", Team2: "D", Winner: "C", Section: "Bracket/4"},
+		{ID: "BR_R02-M001", Team1: "A", Team2: "C", Winner: "A", Section: "Bracket/4"},
+	}
+	result, err := singleElimFormat{}.BuildFromMatchNodes(nodes, "Playoffs")
+	require.NoError(t, err)
+	er, ok := result.(EliminationResult)
+	require.True(t, ok)
+	assert.Equal(t, "Playoffs", er.Round)
+	assert.Equal(t, "advanced", er.Teams["A"].Status)
+	assert.Equal(t, "eliminated", er.Teams["C"].Status)
+}
+
+func TestSingleElimFormat_BuildFromMatchNodes_Empty(t *testing.T) {
+	_, err := singleElimFormat{}.BuildFromMatchNodes(nil, "Playoffs")
+	assert.Error(t, err)
+}
+
+func TestSingleElimFormat_DecodeBSON_RoundTrip(t *testing.T) {
+	original := EliminationResult{
+		Round: "Playoffs",
+		Teams: map[string]models.TeamProgress{
+			"Alpha": {Round: "Grand Final", Status: "advanced"},
+		},
+	}
+	raw, err := bson.Marshal(original)
+	require.NoError(t, err)
+
+	decoded, err := singleElimFormat{}.DecodeBSON(raw)
+	require.NoError(t, err)
+	er, ok := decoded.(EliminationResult)
+	require.True(t, ok)
+	assert.Equal(t, "Playoffs", er.Round)
+	assert.Equal(t, "advanced", er.Teams["Alpha"].Status)
+}
+
+func TestSingleElimFormat_DecodeBSON_InvalidBytes(t *testing.T) {
+	_, err := singleElimFormat{}.DecodeBSON([]byte("not valid bson!!"))
+	assert.Error(t, err)
+}
+
+// endregion

--- a/web/integration_helpers_test.go
+++ b/web/integration_helpers_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package web
+
+import "golang.org/x/time/rate"
+
+// newUnlimitedLimiter returns a rate.Limiter that never blocks.
+// Used in integration tests to prevent rate-limiting from gating rapid
+// sequential calls within a single test.
+func newUnlimitedLimiter() *rate.Limiter {
+	return rate.NewLimiter(rate.Inf, 1)
+}

--- a/web/liquipedia_integration_test.go
+++ b/web/liquipedia_integration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package web
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"pickems-bot/app"
+	"pickems-bot/config"
+	"pickems-bot/testhelpers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadLiquipediaTestCfg loads the integration config overriding data_source to liquipedia.
+func loadLiquipediaTestCfg(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.Load("../testdata/integration_config.toml")
+	require.NoError(t, err)
+	cfg.DataSource = "liquipedia"
+	return cfg
+}
+
+// newLiquipediaTestApp creates a real App wired to the Liquipedia test server.
+func newLiquipediaTestApp(t *testing.T, cfg config.Config, mongoURI string) *app.App {
+	t.Helper()
+	t.Setenv("LIQUIDPEDIADB_API_KEY", "pickems-test-key")
+
+	a, err := app.NewApp(cfg, mongoURI, slog.Default())
+	require.NoError(t, err)
+
+	app.SetRateLimiterForTesting(a, newUnlimitedLimiter())
+
+	t.Cleanup(func() {
+		_ = a.Store.GetClient().Disconnect(context.Background())
+	})
+	return a
+}
+
+// newWebhookServer starts an httptest.Server running the bot's Liquipedia webhook
+// handler, wired to the given App and configured page path.
+func newWebhookServer(t *testing.T, a *app.App, page string) *httptest.Server {
+	t.Helper()
+	var serverLog *slog.Logger
+	srv := &Server{api: a, page: page, log: serverLog}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhooks/liquipedia", srv.LiquipediaWebhookHandler)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// pollUntil repeatedly calls check until it returns true, or the timeout elapses.
+func pollUntil(timeout time.Duration, interval time.Duration, check func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return true
+		}
+		time.Sleep(interval)
+	}
+	return false
+}
+
+// TestLiquipedia_WebhookTriggersUpdate verifies that a Liquipedia webhook callback
+// triggers the full update pipeline and writes new match data to the store.
+func TestLiquipedia_WebhookTriggersUpdate(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	testhelpers.SetState(t, "liquipedia", "ongoing")
+
+	cfg := loadLiquipediaTestCfg(t)
+	a := newLiquipediaTestApp(t, cfg, mongoURI)
+
+	// Populate initial match data so the store is not empty.
+	require.NoError(t, a.PopulateMatches(false))
+
+	// Record the current match state before the webhook fires.
+	nodesBefore, _, err := a.Store.FetchMatchNodesFromDb()
+	require.NoError(t, err)
+
+	// Start the bot's webhook handler.
+	ts := newWebhookServer(t, a, cfg.Liquipedia.Page)
+
+	// Ask the test server to POST the webhook to our handler after 1 second.
+	// page must match cfg.Liquipedia.Page so the handler does not filter it out.
+	testhelpers.FireCallback(t, ts.URL+"/webhooks/liquipedia", 1, cfg.Liquipedia.Page)
+
+	// Advance the server to "complete" so the webhook-triggered fetch actually
+	// returns different (richer) data.
+	testhelpers.SetState(t, "liquipedia", "complete")
+
+	// Poll the store for up to 15 seconds waiting for the pipeline to update.
+	updated := pollUntil(15*time.Second, 500*time.Millisecond, func() bool {
+		nodesAfter, _, err := a.Store.FetchMatchNodesFromDb()
+		if err != nil || len(nodesAfter) == 0 {
+			return false
+		}
+		// Consider updated if the store has data (at least as many nodes as before).
+		return len(nodesAfter) >= len(nodesBefore)
+	})
+	assert.True(t, updated, "store should be updated after webhook callback fires")
+}
+
+// TestLiquipedia_IrrelevantWebhookFiltered verifies that a webhook for a
+// different page is silently ignored — the store is not updated.
+func TestLiquipedia_IrrelevantWebhookFiltered(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	testhelpers.SetState(t, "liquipedia", "ongoing")
+
+	cfg := loadLiquipediaTestCfg(t)
+	a := newLiquipediaTestApp(t, cfg, mongoURI)
+	require.NoError(t, a.PopulateMatches(false))
+
+	ts := newWebhookServer(t, a, cfg.Liquipedia.Page)
+
+	// POST a webhook for a completely different wiki/page directly.
+	body := []byte(`{"wiki":"dota2","page":"Some/Other/Page","event":"match_update"}`)
+	resp, err := http.Post(ts.URL+"/webhooks/liquipedia", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The handler should accept the request (200) but silently discard it.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Give a brief window for any (unwanted) pipeline activity to complete.
+	time.Sleep(300 * time.Millisecond)
+
+	// If the handler leaked the update through, FetchMatchNodesFromDb would
+	// still return the original data — any change here would be a bug.
+	// We just verify the call did not panic and the server is still responsive.
+	_, _, err = a.Store.FetchMatchNodesFromDb()
+	assert.NoError(t, err, "store should be readable after irrelevant webhook")
+}

--- a/web/poller.go
+++ b/web/poller.go
@@ -15,6 +15,7 @@ type Poller struct {
 	app         *app.App
 	seriesID    int
 	apiKey      string
+	apiURL      string
 	interval    time.Duration
 	knownStatus map[string]string // matchID -> last known status
 	log         *slog.Logger
@@ -30,7 +31,7 @@ func (p *Poller) logger() *slog.Logger {
 
 // NewPoller is the poller constructor.
 // log may be nil; if so the global slog default is used.
-func NewPoller(a *app.App, seriesID int, apiKey string, log *slog.Logger) *Poller {
+func NewPoller(a *app.App, seriesID int, apiKey string, apiURL string, log *slog.Logger) *Poller {
 	var pollerLog *slog.Logger
 	if log != nil {
 		pollerLog = log.With("component", "poller")
@@ -39,6 +40,7 @@ func NewPoller(a *app.App, seriesID int, apiKey string, log *slog.Logger) *Polle
 		app:         a,
 		seriesID:    seriesID,
 		apiKey:      apiKey,
+		apiURL:      apiURL,
 		interval:    time.Minute,
 		knownStatus: make(map[string]string),
 		log:         pollerLog,
@@ -66,7 +68,7 @@ func (p *Poller) tick() bool {
 		return true
 	}
 
-	raw, err := sources.GetPandaScoreMatches(p.apiKey, p.seriesID)
+	raw, err := sources.GetPandaScoreMatches(p.apiURL, p.apiKey, p.seriesID)
 	if err != nil {
 		if errors.Is(err, sources.ErrUnrecoverable) {
 			p.logger().Error("unrecoverable fetch error, stopping poller", "error", fmt.Errorf("poller.tick: %w", err))

--- a/web/poller_integration_test.go
+++ b/web/poller_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package web
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"pickems-bot/app"
+	"pickems-bot/config"
+	"pickems-bot/testhelpers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadPollerTestCfg loads the integration config with PandaScore as the source.
+func loadPollerTestCfg(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.Load("../testdata/integration_config.toml")
+	require.NoError(t, err)
+	return cfg
+}
+
+// newPollerTestApp creates a real App for poller integration tests.
+// The rate limiter is set to allow unlimited calls so tick() is never gated.
+func newPollerTestApp(t *testing.T, cfg config.Config, mongoURI string) *app.App {
+	t.Helper()
+	t.Setenv("PANDASCORE_API_KEY", "pickems-test-key")
+
+	a, err := app.NewApp(cfg, mongoURI, slog.Default())
+	require.NoError(t, err)
+
+	// Override to unlimited so rate limiting doesn't interfere with test ticks.
+	app.SetRateLimiterForTesting(a, newUnlimitedLimiter())
+
+	t.Cleanup(func() {
+		_ = a.Store.GetClient().Disconnect(context.Background())
+	})
+	return a
+}
+
+// newTestPoller creates a Poller wired to the integration test server.
+func newTestPoller(t *testing.T, a *app.App, cfg config.Config) *Poller {
+	t.Helper()
+	return NewPoller(a, cfg.PandaScore.SeriesID, "pickems-test-key", cfg.PandaScore.APIURL, nil)
+}
+
+// TestPoller_NoOp verifies that when the server state is unchanged between
+// ticks, the poller does not call UpdateMatchResults and continues running.
+func TestPoller_NoOp(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	testhelpers.SetState(t, "pandascore", "ongoing")
+
+	cfg := loadPollerTestCfg(t)
+	a := newPollerTestApp(t, cfg, mongoURI)
+
+	// Populate so the App's store has data and rate limiter is primed.
+	require.NoError(t, a.PopulateMatches(false))
+
+	p := newTestPoller(t, a, cfg)
+
+	// First tick: establishes the knownStatus baseline; no previous state to
+	// compare against so no transition is detected.
+	assert.True(t, p.tick(), "first tick should return true (keep going)")
+	assert.NotEmpty(t, p.knownStatus, "knownStatus should be populated after first tick")
+	baselineStatus := make(map[string]string, len(p.knownStatus))
+	for k, v := range p.knownStatus {
+		baselineStatus[k] = v
+	}
+
+	// Second tick: same state — no match transitioned to finished, so
+	// UpdateMatchResults must NOT be called and the poller must keep going.
+	assert.True(t, p.tick(), "second tick (no change) should return true")
+	assert.Equal(t, baselineStatus, p.knownStatus,
+		"knownStatus should be unchanged when server state has not changed")
+}
+
+// TestPoller_Transition verifies that when a match transitions to finished
+// between ticks, the poller calls UpdateMatchResults and keeps running.
+func TestPoller_Transition(t *testing.T) {
+	mongoURI := testhelpers.MongoURI(t)
+	testhelpers.SetState(t, "pandascore", "ongoing")
+
+	cfg := loadPollerTestCfg(t)
+	a := newPollerTestApp(t, cfg, mongoURI)
+	require.NoError(t, a.PopulateMatches(false))
+
+	p := newTestPoller(t, a, cfg)
+
+	// First tick: establish baseline. State is "ongoing".
+	assert.True(t, p.tick(), "first tick should return true")
+	assert.NotEmpty(t, p.knownStatus)
+
+	// Advance to "complete": one additional match moves from not_started/running
+	// to finished. The poller must detect this transition and call UpdateMatchResults.
+	testhelpers.SetState(t, "pandascore", "complete")
+
+	// Second tick: detects the transition and updates match results.
+	assert.True(t, p.tick(), "second tick (with transition) should return true")
+
+	// Verify at least one match is now "finished" in knownStatus.
+	finishedCount := 0
+	for _, status := range p.knownStatus {
+		if status == "finished" {
+			finishedCount++
+		}
+	}
+	assert.Greater(t, finishedCount, 0,
+		"after transition tick, at least one match should be finished in knownStatus")
+}

--- a/web/poller_test.go
+++ b/web/poller_test.go
@@ -15,13 +15,13 @@ import (
 // region NewPoller tests
 
 func TestNewPoller_DefaultInterval(t *testing.T) {
-	p := NewPoller(nil, 42, "test-key", nil)
+	p := NewPoller(nil, 42, "test-key", "", nil)
 
 	assert.Equal(t, time.Minute, p.interval)
 }
 
 func TestNewPoller_Fields(t *testing.T) {
-	p := NewPoller(nil, 99, "my-api-key", nil)
+	p := NewPoller(nil, 99, "my-api-key", "", nil)
 
 	assert.Nil(t, p.app)
 	assert.Equal(t, 99, p.seriesID)
@@ -30,7 +30,7 @@ func TestNewPoller_Fields(t *testing.T) {
 
 func TestNewPoller_KnownStatusInitialised(t *testing.T) {
 	// knownStatus map must be initialised — a nil map panics on write
-	p := NewPoller(nil, 1, "key", nil)
+	p := NewPoller(nil, 1, "key", "", nil)
 
 	assert.NotNil(t, p.knownStatus)
 	// writing to it should not panic
@@ -42,7 +42,7 @@ func TestNewPoller_KnownStatusInitialised(t *testing.T) {
 // region knownStatus transition logic tests
 
 func TestPoller_StatusTransition_DetectsFinished(t *testing.T) {
-	p := NewPoller(nil, 1, "key", nil)
+	p := NewPoller(nil, 1, "key", "", nil)
 	p.knownStatus["match-1"] = "running"
 
 	// Simulate a tick where match-1 transitions to finished
@@ -63,7 +63,7 @@ func TestPoller_StatusTransition_DetectsFinished(t *testing.T) {
 
 func TestPoller_StatusTransition_NoTriggerIfAlreadyFinished(t *testing.T) {
 	// A match already marked finished should not trigger again on next tick
-	p := NewPoller(nil, 1, "key", nil)
+	p := NewPoller(nil, 1, "key", "", nil)
 	p.knownStatus["match-1"] = "finished"
 
 	finishedTransition := false
@@ -83,7 +83,7 @@ func TestPoller_StatusTransition_NoTriggerIfAlreadyFinished(t *testing.T) {
 func TestPoller_StatusTransition_NoTriggerForFirstSeen(t *testing.T) {
 	// A brand-new match seen as "finished" (never tracked before) should not trigger —
 	// we only react to transitions, not initial state.
-	p := NewPoller(nil, 1, "key", nil)
+	p := NewPoller(nil, 1, "key", "", nil)
 
 	finishedTransition := false
 	statuses := map[string]string{"match-new": "finished"}

--- a/web/poller_test.go
+++ b/web/poller_test.go
@@ -6,6 +6,7 @@
 package web
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -35,6 +36,22 @@ func TestNewPoller_KnownStatusInitialised(t *testing.T) {
 	assert.NotNil(t, p.knownStatus)
 	// writing to it should not panic
 	p.knownStatus["test-id"] = "not_started"
+}
+
+// endregion
+
+// region logger tests
+
+func TestPoller_Logger_NilLog_ReturnsDefault(t *testing.T) {
+	p := NewPoller(nil, 1, "key", "", nil)
+	l := p.logger()
+	assert.NotNil(t, l)
+}
+
+func TestPoller_Logger_InjectedLog(t *testing.T) {
+	p := NewPoller(nil, 1, "key", "", slog.Default())
+	l := p.logger()
+	assert.NotNil(t, l)
 }
 
 // endregion

--- a/web/tick_test.go
+++ b/web/tick_test.go
@@ -28,8 +28,10 @@ const finishedMatchJSON = `[{"id": 1, "name": "Round 1", "status": "finished",
   "results": [{"team_id": 1, "score": 2}, {"team_id": 2, "score": 0}]
 }]`
 
-// newTestPoller creates a Poller backed by a mock App (unlimited rate limiter).
-func newTestPoller(a *app.App, apiURL string) *Poller {
+// newMockPoller creates a Poller backed by a mock App for unit tests.
+// Named differently from the integration test helper to avoid redeclaration
+// when the binary is compiled with -tags integration.
+func newMockPoller(a *app.App, apiURL string) *Poller {
 	return NewPoller(a, 99001, "test-key", apiURL, nil)
 }
 
@@ -43,7 +45,7 @@ func TestTick_RateLimitReached_ReturnsTrue(t *testing.T) {
 	// NewTestApp gives unlimited; for a nil limiter we need a nil-limiter App.
 	// Use a Poller whose app.Allow() returns false.
 	a := &app.App{Store: mockStore} // rateLimiter is nil → Allow() returns false
-	p := newTestPoller(a, "http://localhost")
+	p := newMockPoller(a, "http://localhost")
 
 	result := p.tick()
 	assert.True(t, result, "tick() must return true when rate-limited (poller keeps running)")
@@ -58,7 +60,7 @@ func TestTick_UnrecoverableError_ReturnsFalse(t *testing.T) {
 
 	mockStore := app.NewMockStore("swiss", "test_round")
 	a := app.NewTestApp(mockStore)
-	p := newTestPoller(a, srv.URL)
+	p := newMockPoller(a, srv.URL)
 
 	result := p.tick()
 	assert.False(t, result, "tick() must return false on unrecoverable error")
@@ -73,7 +75,7 @@ func TestTick_RetriableError_ReturnsTrue(t *testing.T) {
 
 	mockStore := app.NewMockStore("swiss", "test_round")
 	a := app.NewTestApp(mockStore)
-	p := newTestPoller(a, srv.URL)
+	p := newMockPoller(a, srv.URL)
 
 	result := p.tick()
 	assert.True(t, result, "tick() must return true on retriable error")
@@ -89,7 +91,7 @@ func TestTick_ParseError_ReturnsTrue(t *testing.T) {
 
 	mockStore := app.NewMockStore("swiss", "test_round")
 	a := app.NewTestApp(mockStore)
-	p := newTestPoller(a, srv.URL)
+	p := newMockPoller(a, srv.URL)
 
 	result := p.tick()
 	assert.True(t, result, "tick() must return true on parse error (will retry)")
@@ -105,7 +107,7 @@ func TestTick_NoTransition_ReturnsTrue(t *testing.T) {
 
 	mockStore := app.NewMockStore("swiss", "test_round")
 	a := app.NewTestApp(mockStore)
-	p := newTestPoller(a, srv.URL)
+	p := newMockPoller(a, srv.URL)
 
 	result := p.tick()
 	assert.True(t, result)
@@ -128,7 +130,7 @@ func TestTick_FinishedTransition_TriggersUpdateAndReturnsTrue(t *testing.T) {
 	})
 
 	a := app.NewTestApp(mockStore)
-	p := newTestPoller(a, srv.URL)
+	p := newMockPoller(a, srv.URL)
 
 	// Seed knownStatus so the match looks like it was "running" before this tick.
 	p.knownStatus["1"] = "running"

--- a/web/tick_test.go
+++ b/web/tick_test.go
@@ -1,0 +1,141 @@
+/* tick_test.go
+ * Unit tests for Poller.tick() using httptest servers and a mock App.
+ */
+
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"pickems-bot/app"
+	"pickems-bot/sources"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// notStartedMatchJSON is a minimal valid PandaScore response with no finished matches.
+const notStartedMatchJSON = `[{"id": 1, "name": "Round 1", "status": "not_started", "opponents": [], "winner": null, "results": []}]`
+
+// finishedMatchJSON is a minimal PandaScore response where match 1 is finished.
+const finishedMatchJSON = `[{"id": 1, "name": "Round 1", "status": "finished",
+  "opponents": [
+    {"opponent": {"name": "Alpha", "id": 1}},
+    {"opponent": {"name": "Beta",  "id": 2}}
+  ],
+  "winner": {"name": "Alpha"},
+  "results": [{"team_id": 1, "score": 2}, {"team_id": 2, "score": 0}]
+}]`
+
+// newTestPoller creates a Poller backed by a mock App (unlimited rate limiter).
+func newTestPoller(a *app.App, apiURL string) *Poller {
+	return NewPoller(a, 99001, "test-key", apiURL, nil)
+}
+
+// region tick() tests
+
+func TestTick_RateLimitReached_ReturnsTrue(t *testing.T) {
+	// An App with a nil rateLimiter causes Allow() to return false →
+	// tick() logs a warning and returns true (poller continues).
+	mockStore := app.NewMockStore("swiss", "test_round")
+	// Construct an App with nil rate limiter directly using the exported mock helper
+	// NewTestApp gives unlimited; for a nil limiter we need a nil-limiter App.
+	// Use a Poller whose app.Allow() returns false.
+	a := &app.App{Store: mockStore} // rateLimiter is nil → Allow() returns false
+	p := newTestPoller(a, "http://localhost")
+
+	result := p.tick()
+	assert.True(t, result, "tick() must return true when rate-limited (poller keeps running)")
+}
+
+func TestTick_UnrecoverableError_ReturnsFalse(t *testing.T) {
+	// PandaScore returns 401 → ErrUnrecoverable → tick() returns false.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	mockStore := app.NewMockStore("swiss", "test_round")
+	a := app.NewTestApp(mockStore)
+	p := newTestPoller(a, srv.URL)
+
+	result := p.tick()
+	assert.False(t, result, "tick() must return false on unrecoverable error")
+}
+
+func TestTick_RetriableError_ReturnsTrue(t *testing.T) {
+	// PandaScore returns 500 → retriable error → tick() returns true.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	mockStore := app.NewMockStore("swiss", "test_round")
+	a := app.NewTestApp(mockStore)
+	p := newTestPoller(a, srv.URL)
+
+	result := p.tick()
+	assert.True(t, result, "tick() must return true on retriable error")
+}
+
+func TestTick_ParseError_ReturnsTrue(t *testing.T) {
+	// PandaScore returns invalid JSON → parse error → tick() returns true.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not valid json {{"))
+	}))
+	defer srv.Close()
+
+	mockStore := app.NewMockStore("swiss", "test_round")
+	a := app.NewTestApp(mockStore)
+	p := newTestPoller(a, srv.URL)
+
+	result := p.tick()
+	assert.True(t, result, "tick() must return true on parse error (will retry)")
+}
+
+func TestTick_NoTransition_ReturnsTrue(t *testing.T) {
+	// Server returns not_started match; knownStatus empty → no transition → returns true.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(notStartedMatchJSON))
+	}))
+	defer srv.Close()
+
+	mockStore := app.NewMockStore("swiss", "test_round")
+	a := app.NewTestApp(mockStore)
+	p := newTestPoller(a, srv.URL)
+
+	result := p.tick()
+	assert.True(t, result)
+	assert.Equal(t, "not_started", p.knownStatus["1"])
+}
+
+func TestTick_FinishedTransition_TriggersUpdateAndReturnsTrue(t *testing.T) {
+	// Simulate a match transitioning from running → finished across two ticks.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(finishedMatchJSON))
+	}))
+	defer srv.Close()
+
+	mockStore := app.NewMockStore("swiss", "test_round")
+	// Give the mock store some scheduled matches so EnsureScheduledMatches passes
+	// (called inside GenerateLeaderboard via tick's finishedTransition branch).
+	mockStore.SetScheduledMatches([]sources.ScheduledMatch{
+		{Team1: "Alpha", Team2: "Beta"},
+	})
+
+	a := app.NewTestApp(mockStore)
+	p := newTestPoller(a, srv.URL)
+
+	// Seed knownStatus so the match looks like it was "running" before this tick.
+	p.knownStatus["1"] = "running"
+
+	result := p.tick()
+	assert.True(t, result, "tick() must return true after processing a finished transition")
+	assert.Equal(t, "finished", p.knownStatus["1"])
+}
+
+// endregion


### PR DESCRIPTION
- Restructure config to nested [liquipedia] and [pandascore] TOML sections with required api_url fields per source
- Thread apiURL through the full call stack: sources, store fetchers, poller, app, and main — no more hardcoded production URLs
- Add integration test suite (//go:build integration) covering:
  - PandaScore and Liquipedia source-layer HTTP scenarios
  - App-level PopulateMatches pipeline (initial fetch, empty, 404, wrong key)
  - Poller tick no-op and transition detection
  - Liquipedia webhook trigger and irrelevant-webhook filtering
- Add testdata/integration_config.toml and testhelpers package with SetState, FireCallback, and MongoURI helpers
- Wire pickems-test-server into docker-compose.yml under integration profile
- Add integration-test CI job using service containers (mongo + test server)
- Fix .gitignore to cover **/resources/result.png at any depth