### PR TITLE
feat: replace SSH deploy with GHCR publish + Watchtower CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,39 +1,47 @@
-name: CD - Deploy App
-on: 
-  push:
-    branches:
-      - main
+name: CD - Publish Docker Image
 
-jobs:  
-  build-and-deploy:
-    name: Build and Deploy
+# Fires only when a version tag is pushed (e.g. v1.0.0, v2.3.1).
+# The image is NOT published on every push to main — only on explicit releases.
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Build and Push Docker Image
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write   # allows GITHUB_TOKEN to push to GHCR
+
     steps:
-      # 1. Checkout repository
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # 2. Setup Tailscale via OIDC (no secrets required)
-      - name: Setup Tailscale via OIDC
-        uses: tailscale/github-action@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          oidc: true
-          hostname: github-runner
-          version: latest
-          args: up --accept-dns=true
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # 3. Debug Tailscale connectivity (optional)
-      - name: Test Tailscale connection
-        run: |
-          ping -c 4 100.109.98.83 || echo "Ping failed"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      # 4. Setup SSH key for deployment
-      - name: Setup SSH Key
-        uses: webfactory/ssh-agent@v0.5.4
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      # 5. Run the deploy script on your VM
-      - name: Deploy Script
-        run: |
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null latte@100.109.98.83 '/usr/bin/sh -s' < ./scripts/deploy.sh
+          context: .
+          push: true
+          # 'latest' is what Watchtower watches on the server.
+          # The version tag (e.g. v1.0.0) gives a pinned reference for rollbacks:
+          #   docker pull ghcr.io/zacharyab24/pickems-bot:v1.0.0
+          tags: |
+            ghcr.io/zacharyab24/pickems-bot:latest
+            ghcr.io/zacharyab24/pickems-bot:${{ github.ref_name }}
+          # Re-use the layer cache from previous builds so only changed
+          # layers are rebuilt — keeps publish times short.
+          cache-from: type=registry,ref=ghcr.io/zacharyab24/pickems-bot:buildcache
+          cache-to: type=registry,ref=ghcr.io/zacharyab24/pickems-bot:buildcache,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,23 @@
 services:
   app:
+    image: ghcr.io/zacharyab24/pickems-bot:latest
     container_name: pickems-bot
-    build:
-      context: .
-      dockerfile: Dockerfile
     env_file:
       - .env
     ports:
       - "8080:8080"
+    restart: unless-stopped
+
+  # Watchtower watches the running containers and restarts them whenever a
+  # newer image is available on the registry. It polls every 300 seconds
+  # (5 minutes) and removes old images after updating (--cleanup).
+  # No credentials needed if the GHCR package is set to public visibility.
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 300 --cleanup
     restart: unless-stopped
 
   test-server:


### PR DESCRIPTION
cd.yml: rewritten to trigger on version tags (v*) instead of every push to main. Builds the bot image and pushes two tags to GHCR:
  ghcr.io/zacharyab24/pickems-bot:latest     (Watchtower tracks this)
  ghcr.io/zacharyab24/pickems-bot:<tag>      (pinned ref for rollbacks)
Layer caching via a dedicated buildcache tag keeps subsequent builds fast.
Removes the old Tailscale + SSH deploy flow entirely.

docker-compose.yml: switches the app service from build-from-source to pulling the pre-built GHCR image. Adds a Watchtower sidecar that polls GHCR every 5 minutes and restarts the bot when the 'latest' digest changes, removing the old image after update (--cleanup).

One-time steps on the server to migrate:
  1. Make the pickems-bot GHCR package public (GitHub → Packages → pickems-bot → Package settings → Change visibility)
  2. docker compose pull
  3. docker compose up -d