### PR TITLE
fix: mount config.toml as volume instead of baking into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /app
 
 COPY --from=builder /app/pickems .
 COPY resources/ resources/
-COPY config.toml .
 
 # Required environment variables at runtime:
 #   DISCORD_PROD_TOKEN    - Discord bot token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: pickems-bot
     env_file:
       - .env
+    volumes:
+      - ./config.toml:/app/config.toml:ro
     ports:
       - "8080:8080"
     restart: unless-stopped


### PR DESCRIPTION
config.toml is gitignored (contains tournament config that changes per event). Baking it in with COPY caused the CD build to fail since the file doesn't exist in the Actions runner's checkout.

Instead, mount it as a read-only volume at runtime. The server needs a config.toml alongside docker-compose.yml — same as it needed one alongside the binary before.