### PR TITLE
feat: centralized team name normalization and PandaScore tournament filtering

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -279,18 +279,6 @@ func (a *App) GetLeaderboard() ([]LeaderboardUser, error) {
 	return response, nil
 }
 
-// normalizeForVRSLookup strips common team name decorators so tournament names
-// (e.g. "Team Liquid", "Sharks Esports") match VRS names (e.g. "Liquid", "Sharks").
-// Used only for map key comparison — original names are never modified.
-func normalizeForVRSLookup(name string) string {
-	s := strings.ToLower(name)
-	s = strings.TrimPrefix(s, "team ")
-	s = strings.TrimSuffix(s, " team")
-	s = strings.TrimSuffix(s, " esports")
-	s = strings.TrimSuffix(s, " gaming")
-	return strings.TrimSpace(s)
-}
-
 // GetTeams gets a list of all valid team names.
 // The valid teams list must be initialized in db.
 // It returns a string slice containing all valid teams for this round.
@@ -311,14 +299,14 @@ func (a *App) GetTeams() ([]Team, error) {
 	vrsNorm := make(map[string]int, len(VRSEntries))
 	vrsNormKeys := make([]string, 0, len(VRSEntries))
 	for _, entry := range VRSEntries {
-		key := normalizeForVRSLookup(entry.TeamName)
+		key := sources.NormalizeTeamName(entry.TeamName)
 		vrsNorm[key] = entry.Standing
 		vrsNormKeys = append(vrsNormKeys, key)
 	}
 
 	var result []Team
 	for _, teamName := range validTeams {
-		norm := normalizeForVRSLookup(teamName)
+		norm := sources.NormalizeTeamName(teamName)
 		ranking, ok := vrsNorm[norm]
 		if !ok {
 			// Normalised exact match failed — spacing/punctuation difference; try fuzzy
@@ -346,9 +334,9 @@ func (a *App) GetTeam(teamName string) (store.VRSEntry, error) {
 		return store.VRSEntry{}, err
 	}
 
-	norm := normalizeForVRSLookup(teamName)
+	norm := sources.NormalizeTeamName(teamName)
 	for _, entry := range VRSEntries {
-		if normalizeForVRSLookup(entry.TeamName) == norm {
+		if sources.NormalizeTeamName(entry.TeamName) == norm {
 			return entry, nil
 		}
 	}
@@ -356,11 +344,11 @@ func (a *App) GetTeam(teamName string) (store.VRSEntry, error) {
 	// Exact normalised match failed — try fuzzy
 	keys := make([]string, len(VRSEntries))
 	for i, e := range VRSEntries {
-		keys[i] = normalizeForVRSLookup(e.TeamName)
+		keys[i] = sources.NormalizeTeamName(e.TeamName)
 	}
 	if matches := fuzzy.RankFind(norm, keys); len(matches) > 0 {
 		for _, entry := range VRSEntries {
-			if normalizeForVRSLookup(entry.TeamName) == matches[0].Target {
+			if sources.NormalizeTeamName(entry.TeamName) == matches[0].Target {
 				return entry, nil
 			}
 		}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -383,9 +383,9 @@ func TestGetTeams_StoreError(t *testing.T) {
 
 // endregion
 
-// region normalizeForVRSLookup tests
+// region NormalizeTeamName tests
 
-func TestNormalizeForVRSLookup(t *testing.T) {
+func TestNormalizeTeamName(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string
@@ -394,17 +394,20 @@ func TestNormalizeForVRSLookup(t *testing.T) {
 		{"BetBoom Team", "betboom"},
 		{"Sharks Esports", "sharks"},
 		{"Lynn Vision Gaming", "lynn vision"},
+		{"FaZe Clan", "faze"},
 		{"HEROIC", "heroic"},
 		{"The MongolZ", "the mongolz"},
 		{"FaZe", "faze"},
+		{"Na'Vi", "navi"},
+		{"OG.", "og"},
 		{"", ""},
 		{"team liquid", "liquid"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {
-			got := normalizeForVRSLookup(tc.input)
+			got := sources.NormalizeTeamName(tc.input)
 			if got != tc.want {
-				t.Errorf("normalizeForVRSLookup(%q) = %q, want %q", tc.input, got, tc.want)
+				t.Errorf("NormalizeTeamName(%q) = %q, want %q", tc.input, got, tc.want)
 			}
 		})
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,8 @@ services:
   app:
     image: ghcr.io/zacharyab24/pickems-bot:latest
     container_name: pickems-bot
-    env_file:
-      - .env
     volumes:
+      - ./.env:/app/.env:ro
       - ./config.toml:/app/config.toml:ro
     ports:
       - "8080:8080"

--- a/scoring/input_processing.go
+++ b/scoring/input_processing.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"pickems-bot/models"
+	"pickems-bot/sources"
 	"pickems-bot/tournament"
 
 	"github.com/lithammer/fuzzysearch/fuzzy"
@@ -60,10 +61,60 @@ func CheckTeamNames(predictionTeams []string, validTeams []string) ([]string, []
 // CalculateUserScore calculates a user's score based on their predictions by
 // dispatching through the format registry — the per-format scoring lives in
 // the tournament package.
+// Team names in the prediction are resolved against the result's team names before
+// scoring, handling mismatches between data sources (e.g. "FaZe Clan" vs "FaZe").
 func CalculateUserScore(userPrediction models.Prediction, results tournament.MatchResult) (tournament.ScoreReport, error) {
 	f, err := tournament.Get(tournament.Kind(results.GetType()))
 	if err != nil {
 		return nil, err
 	}
+	userPrediction = resolveNamesInPrediction(userPrediction, results.GetTeamNames())
 	return f.CalculateScore(userPrediction, results)
+}
+
+// resolveNamesInPrediction normalises prediction team names to match the canonical
+// names in the result, handling cross-source mismatches. Normalisation runs first;
+// fuzzy matching is the fallback for cases normalisation cannot resolve (e.g. abbreviations).
+// The original stored prediction is never modified.
+func resolveNamesInPrediction(p models.Prediction, validTeams []string) models.Prediction {
+	normToOriginal := make(map[string]string, len(validTeams))
+	normKeys := make([]string, 0, len(validTeams))
+	for _, vt := range validTeams {
+		k := sources.NormalizeTeamName(vt)
+		normToOriginal[k] = vt
+		normKeys = append(normKeys, k)
+	}
+
+	resolve := func(name string) string {
+		norm := sources.NormalizeTeamName(name)
+		if original, ok := normToOriginal[norm]; ok {
+			return original
+		}
+		if matches := fuzzy.RankFind(norm, normKeys); len(matches) > 0 {
+			return normToOriginal[matches[0].Target]
+		}
+		return name
+	}
+
+	resolveSlice := func(names []string) []string {
+		out := make([]string, len(names))
+		for i, n := range names {
+			out[i] = resolve(n)
+		}
+		return out
+	}
+
+	p.Win = resolveSlice(p.Win)
+	p.Advance = resolveSlice(p.Advance)
+	p.Lose = resolveSlice(p.Lose)
+
+	if len(p.Progression) > 0 {
+		resolved := make(map[string]models.TeamProgress, len(p.Progression))
+		for name, progress := range p.Progression {
+			resolved[resolve(name)] = progress
+		}
+		p.Progression = resolved
+	}
+
+	return p
 }

--- a/scripts/configure/configure.go
+++ b/scripts/configure/configure.go
@@ -32,7 +32,8 @@ type tournamentConfig struct {
 	Format string // empty = auto-detect; set to "swiss" or "single-elimination" for multi-stage pages
 
 	// PandaScore only
-	SeriesID int
+	SeriesID     int
+	TournamentID int // optional; narrows to a single stage within the series
 }
 
 const (
@@ -235,7 +236,8 @@ func writeConfig(path string, c tournamentConfig) error {
 		psAPIURL = pandaScoreProdAPIURL
 	}
 	fmt.Fprintln(f, "[pandascore]")
-	fmt.Fprintf(f, "api_url   = %q\n", psAPIURL)
-	fmt.Fprintf(f, "series_id = %d\n", c.SeriesID)
+	fmt.Fprintf(f, "api_url       = %q\n", psAPIURL)
+	fmt.Fprintf(f, "series_id     = %d\n", c.SeriesID)
+	fmt.Fprintf(f, "tournament_id = %d\n", c.TournamentID)
 	return nil
 }

--- a/scripts/configure/main.go
+++ b/scripts/configure/main.go
@@ -32,6 +32,7 @@ func main() {
 
 	// PandaScore flags
 	seriesID := flag.Int("series-id", 0, "PandaScore series ID (pandascore source only)")
+	tournamentID := flag.Int("tournament-id", 0, "PandaScore tournament ID to narrow to a single stage (pandascore source only)")
 	name := flag.String("name", "", "Tournament name, used as MongoDB database name (pandascore source only)")
 	round := flag.String("round", "", "Round/stage name (pandascore source only)")
 
@@ -44,7 +45,7 @@ func main() {
 		cfg = runLiquipedia(*tourneyURL, *stage, *format)
 
 	case "pandascore":
-		cfg = runPandaScore(*seriesID, *name, *round)
+		cfg = runPandaScore(*seriesID, *tournamentID, *name, *round)
 
 	default:
 		log.Fatalf("unknown -source %q — use \"liquipedia\" or \"pandascore\"", *source)
@@ -62,6 +63,9 @@ func main() {
 		fmt.Printf("  page            = %q\n", cfg.Page)
 	case "pandascore":
 		fmt.Printf("  series_id       = %d\n", cfg.SeriesID)
+		if cfg.TournamentID != 0 {
+			fmt.Printf("  tournament_id   = %d\n", cfg.TournamentID)
+		}
 	}
 }
 
@@ -109,7 +113,7 @@ func runLiquipedia(tourneyURL, stage, format string) tournamentConfig {
 	}
 }
 
-func runPandaScore(seriesID int, name, round string) tournamentConfig {
+func runPandaScore(seriesID int, tournamentID int, name, round string) tournamentConfig {
 	if seriesID == 0 {
 		log.Fatal("missing required flag: -series-id")
 	}
@@ -121,9 +125,10 @@ func runPandaScore(seriesID int, name, round string) tournamentConfig {
 	}
 
 	return tournamentConfig{
-		DataSource: "pandascore",
-		Name:       mongoSafe(name),
-		SeriesID:   seriesID,
-		Round:      round,
+		DataSource:   "pandascore",
+		Name:         mongoSafe(name),
+		SeriesID:     seriesID,
+		TournamentID: tournamentID,
+		Round:        round,
 	}
 }

--- a/scripts/configure/main_test.go
+++ b/scripts/configure/main_test.go
@@ -241,8 +241,9 @@ func TestWriteConfig_Liquipedia(t *testing.T) {
 	assert.Contains(t, out, `format  = "swiss"`)
 	// PandaScore section always written, but api_url is blank when not the active source
 	assert.Contains(t, out, "[pandascore]")
-	assert.Contains(t, out, `api_url   = ""`)
-	assert.Contains(t, out, "series_id = 0")
+	assert.Contains(t, out, `api_url       = ""`)
+	assert.Contains(t, out, "series_id     = 0")
+	assert.Contains(t, out, "tournament_id = 0")
 }
 
 func TestWriteConfig_PandaScore(t *testing.T) {
@@ -250,10 +251,11 @@ func TestWriteConfig_PandaScore(t *testing.T) {
 	path := filepath.Join(dir, "out.toml")
 
 	cfg := tournamentConfig{
-		DataSource: "pandascore",
-		Name:       "IEM_Cologne_2026",
-		SeriesID:   10488,
-		Round:      "Stage_1",
+		DataSource:   "pandascore",
+		Name:         "IEM_Cologne_2026",
+		SeriesID:     10488,
+		TournamentID: 20708,
+		Round:        "Stage_1",
 	}
 	err := writeConfig(path, cfg)
 	assert.NoError(t, err)
@@ -266,11 +268,10 @@ func TestWriteConfig_PandaScore(t *testing.T) {
 	assert.Contains(t, out, `data_source     = "pandascore"`)
 	assert.Contains(t, out, `tournament_name = "IEM_Cologne_2026"`)
 	assert.Contains(t, out, `round           = "Stage_1"`)
-	// Nested pandascore section
 	assert.Contains(t, out, "[pandascore]")
-	assert.Contains(t, out, `api_url   = "https://api.pandascore.co/csgo/matches"`)
-	assert.Contains(t, out, "series_id = 10488")
-	// Liquipedia section always written, but api_url is blank when not the active source
+	assert.Contains(t, out, `api_url       = "https://api.pandascore.co/csgo/matches"`)
+	assert.Contains(t, out, "series_id     = 10488")
+	assert.Contains(t, out, "tournament_id = 20708")
 	assert.Contains(t, out, "[liquipedia]")
 	assert.Contains(t, out, `api_url = ""`)
 }

--- a/sources/pandascore.go
+++ b/sources/pandascore.go
@@ -17,7 +17,9 @@ import (
 var ErrUnrecoverable = errors.New("unrecoverable api error")
 
 // GetPandaScoreMatches fetches matches from the PandaScore API.
-// When tournamentID is non-zero it filters by tournament (single stage); otherwise filters by seriesID (all stages).
+// When tournamentID is non-zero it is used as the server-side filter; the caller is also
+// responsible for client-side filtering since PandaScore's filter[tournament_id] is
+// unreliable for finished matches. Falls back to filter[serie_id] when tournamentID is zero.
 // Returns the raw JSON response body as a string.
 func GetPandaScoreMatches(apiURL string, apiKey string, seriesID int, tournamentID int) (string, error) {
 	parsedURL, err := url.Parse(apiURL)
@@ -66,15 +68,35 @@ func GetPandaScoreMatches(apiURL string, apiKey string, seriesID int, tournament
 	return string(body), nil
 }
 
+// filterByTournament removes raw match objects whose tournament_id does not match the given ID.
+// When tournamentID is 0 the slice is returned unchanged.
+func filterByTournament(raw []interface{}, tournamentID int) []interface{} {
+	if tournamentID == 0 {
+		return raw
+	}
+	var filtered []interface{}
+	for _, item := range raw {
+		match, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if tid, ok := match["tournament_id"].(float64); ok && int(tid) == tournamentID {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
 // ParsePandaScoreMatches parses a PandaScore matches JSON response into a slice of MatchNodes.
-func ParsePandaScoreMatches(matchData string) ([]MatchNode, error) {
+// When tournamentID is non-zero only matches belonging to that tournament are returned.
+func ParsePandaScoreMatches(matchData string, tournamentID int) ([]MatchNode, error) {
 	var raw []interface{}
 	if err := json.Unmarshal([]byte(matchData), &raw); err != nil {
 		return nil, fmt.Errorf("error parsing JSON: %w", err)
 	}
 
 	var matchNodes []MatchNode
-	for _, result := range raw {
+	for _, result := range filterByTournament(raw, tournamentID) {
 		node, err := parsePandaScoreMatch(result)
 		if err != nil {
 			return nil, err
@@ -161,14 +183,15 @@ func parsePandaScoreMatch(result interface{}) (*MatchNode, error) {
 }
 
 // ParsePandaScoreSchedule parses a PandaScore matches JSON response into a slice of ScheduledMatches.
-func ParsePandaScoreSchedule(matchData string) ([]ScheduledMatch, error) {
+// When tournamentID is non-zero only matches belonging to that tournament are returned.
+func ParsePandaScoreSchedule(matchData string, tournamentID int) ([]ScheduledMatch, error) {
 	var raw []interface{}
 	if err := json.Unmarshal([]byte(matchData), &raw); err != nil {
 		return nil, fmt.Errorf("error parsing JSON: %w", err)
 	}
 
 	var scheduledMatches []ScheduledMatch
-	for _, result := range raw {
+	for _, result := range filterByTournament(raw, tournamentID) {
 		match, err := parsePandaScoreScheduledMatch(result)
 		if err != nil {
 			return nil, err

--- a/sources/pandascore_integration_test.go
+++ b/sources/pandascore_integration_test.go
@@ -24,10 +24,10 @@ const (
 func TestPandaScore_GetMatches_Ongoing(t *testing.T) {
 	testhelpers.SetState(t, "pandascore", "ongoing")
 
-	raw, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	raw, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID, 0)
 	require.NoError(t, err)
 
-	nodes, err := sources.ParsePandaScoreMatches(raw)
+	nodes, err := sources.ParsePandaScoreMatches(raw, 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, nodes, "expected matches in ongoing state")
 
@@ -43,10 +43,10 @@ func TestPandaScore_GetMatches_Ongoing(t *testing.T) {
 func TestPandaScore_GetMatches_NotStarted(t *testing.T) {
 	testhelpers.SetState(t, "pandascore", "not_started")
 
-	raw, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	raw, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID, 0)
 	require.NoError(t, err)
 
-	nodes, err := sources.ParsePandaScoreMatches(raw)
+	nodes, err := sources.ParsePandaScoreMatches(raw, 0)
 	require.NoError(t, err)
 	assert.Empty(t, nodes, "expected empty match list in not_started state")
 }
@@ -56,7 +56,7 @@ func TestPandaScore_GetMatches_NotStarted(t *testing.T) {
 func TestPandaScore_GetMatches_WrongKey(t *testing.T) {
 	testhelpers.SetState(t, "pandascore", "ongoing")
 
-	_, err := sources.GetPandaScoreMatches(psURL, "wrong-key", psSeriesID)
+	_, err := sources.GetPandaScoreMatches(psURL, "wrong-key", psSeriesID, 0)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, sources.ErrUnrecoverable),
 		"expected ErrUnrecoverable for bad API key, got: %v", err)
@@ -67,7 +67,7 @@ func TestPandaScore_GetMatches_WrongKey(t *testing.T) {
 func TestPandaScore_GetMatches_NotFound(t *testing.T) {
 	// The test server returns 404 when filter[serie_id] is present but not "99001".
 	// Use any other value to trigger this.
-	_, err := sources.GetPandaScoreMatches(psURL, psTestKey, 12345)
+	_, err := sources.GetPandaScoreMatches(psURL, psTestKey, 12345, 0)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, sources.ErrUnrecoverable),
 		"expected ErrUnrecoverable for unknown series ID, got: %v", err)
@@ -77,15 +77,15 @@ func TestPandaScore_GetMatches_NotFound(t *testing.T) {
 // at least one more finished match than the ongoing state.
 func TestPandaScore_Complete_HasMoreFinished(t *testing.T) {
 	testhelpers.SetState(t, "pandascore", "ongoing")
-	rawOngoing, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	rawOngoing, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID, 0)
 	require.NoError(t, err)
-	ongoingNodes, err := sources.ParsePandaScoreMatches(rawOngoing)
+	ongoingNodes, err := sources.ParsePandaScoreMatches(rawOngoing, 0)
 	require.NoError(t, err)
 
 	testhelpers.SetState(t, "pandascore", "complete")
-	rawComplete, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID)
+	rawComplete, err := sources.GetPandaScoreMatches(psURL, psTestKey, psSeriesID, 0)
 	require.NoError(t, err)
-	completeNodes, err := sources.ParsePandaScoreMatches(rawComplete)
+	completeNodes, err := sources.ParsePandaScoreMatches(rawComplete, 0)
 	require.NoError(t, err)
 
 	countFinished := func(nodes []sources.MatchNode) int {

--- a/sources/pandascore_test.go
+++ b/sources/pandascore_test.go
@@ -148,7 +148,7 @@ func TestParsePandaScoreMatches_StatusPopulated(t *testing.T) {
 		 "winner": null, "results": []}
 	]`
 
-	nodes, err := ParsePandaScoreMatches(json)
+	nodes, err := ParsePandaScoreMatches(json, 0)
 
 	require.NoError(t, err)
 	require.Len(t, nodes, 2)
@@ -174,7 +174,7 @@ func TestParsePandaScoreSchedule_TwitchOnly(t *testing.T) {
 		]
 	}]`
 
-	matches, err := ParsePandaScoreSchedule(json)
+	matches, err := ParsePandaScoreSchedule(json, 0)
 
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
@@ -195,7 +195,7 @@ func TestParsePandaScoreSchedule_KickOnly(t *testing.T) {
 		]
 	}]`
 
-	matches, err := ParsePandaScoreSchedule(json)
+	matches, err := ParsePandaScoreSchedule(json, 0)
 
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
@@ -218,7 +218,7 @@ func TestParsePandaScoreSchedule_TwitchPriorityWhenKickFirst(t *testing.T) {
 		]
 	}]`
 
-	matches, err := ParsePandaScoreSchedule(json)
+	matches, err := ParsePandaScoreSchedule(json, 0)
 
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
@@ -241,7 +241,7 @@ func TestParsePandaScoreSchedule_NonOfficialStreamsIgnored(t *testing.T) {
 		]
 	}]`
 
-	matches, err := ParsePandaScoreSchedule(json)
+	matches, err := ParsePandaScoreSchedule(json, 0)
 
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
@@ -261,7 +261,7 @@ func TestParsePandaScoreSchedule_NoStream(t *testing.T) {
 		"streams_list": []
 	}]`
 
-	matches, err := ParsePandaScoreSchedule(json)
+	matches, err := ParsePandaScoreSchedule(json, 0)
 
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
@@ -280,7 +280,7 @@ func TestParsePandaScoreSchedule_FinishedMatch(t *testing.T) {
 		"streams_list": []
 	}]`
 
-	matches, err := ParsePandaScoreSchedule(json)
+	matches, err := ParsePandaScoreSchedule(json, 0)
 
 	require.NoError(t, err)
 	require.Len(t, matches, 1)

--- a/sources/teamname.go
+++ b/sources/teamname.go
@@ -1,0 +1,17 @@
+package sources
+
+import "strings"
+
+// NormalizeTeamName returns a canonical lowercase key used for cross-source name
+// comparison (PandaScore, Liquipedia, VRS). The original name is never modified —
+// this function is only for map keys and comparisons, not display.
+func NormalizeTeamName(name string) string {
+	s := strings.ToLower(name)
+	s = strings.TrimPrefix(s, "team ")
+	for _, suffix := range []string{" team", " esports", " gaming", " clan", " org", " organization"} {
+		s = strings.TrimSuffix(s, suffix)
+	}
+	s = strings.ReplaceAll(s, "'", "")
+	s = strings.ReplaceAll(s, ".", "")
+	return strings.TrimSpace(s)
+}

--- a/store/datasource.go
+++ b/store/datasource.go
@@ -85,7 +85,7 @@ func (f PandaScoreFetcher) FetchMatchData(round string) (tournament.MatchResult,
 		return nil, nil, err
 	}
 
-	matchNodes, err := sources.ParsePandaScoreMatches(matchData)
+	matchNodes, err := sources.ParsePandaScoreMatches(matchData, f.tournamentID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,7 +117,7 @@ func (f PandaScoreFetcher) FetchSchedule() ([]sources.ScheduledMatch, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sources.ParsePandaScoreSchedule(matchData)
+	return sources.ParsePandaScoreSchedule(matchData, f.tournamentID)
 }
 
 // Compile time assertions to ensure interface impls have all methods defined

--- a/testdata/integration_config.toml
+++ b/testdata/integration_config.toml
@@ -16,4 +16,5 @@ format  = ""
 
 [pandascore]
 api_url   = "http://localhost:8081/pandascore/csgo/matches"
-series_id = 99001
+series_id     = 99001
+tournament_id = 0

--- a/web/poller.go
+++ b/web/poller.go
@@ -83,7 +83,7 @@ func (p *Poller) tick() bool {
 		return true
 	}
 
-	matchNodes, err := sources.ParsePandaScoreMatches(raw)
+	matchNodes, err := sources.ParsePandaScoreMatches(raw, p.tournamentID)
 	if err != nil {
 		p.logger().Warn("failed to parse PandaScore matches, will retry next tick", "error", fmt.Errorf("poller.tick: %w", err))
 		metrics.PollerErrorsTotal.Inc()

--- a/web/poller_integration_test.go
+++ b/web/poller_integration_test.go
@@ -44,7 +44,7 @@ func newPollerTestApp(t *testing.T, cfg config.Config, mongoURI string) *app.App
 // newTestPoller creates a Poller wired to the integration test server.
 func newTestPoller(t *testing.T, a *app.App, cfg config.Config) *Poller {
 	t.Helper()
-	return NewPoller(a, cfg.PandaScore.SeriesID, "pickems-test-key", cfg.PandaScore.APIURL, nil)
+	return NewPoller(a, cfg.PandaScore.SeriesID, cfg.PandaScore.TournamentID, "pickems-test-key", cfg.PandaScore.APIURL, nil)
 }
 
 // TestPoller_NoOp verifies that when the server state is unchanged between


### PR DESCRIPTION
- Add sources.NormalizeTeamName — shared normalization function used by all components (VRS lookup, scoring, future sources) to produce consistent comparison keys across PandaScore, Liquipedia, and VRS name formats. Strips decorators (Team/Esports/Gaming/Clan/Org), lowercases, removes punctuation. Original display names are never modified.
- Add resolveNamesInPrediction to scoring.CalculateUserScore — normalizes prediction team names against result team names before scoring, with fuzzy fallback for abbreviation mismatches (e.g. NAVI vs Natus Vincere). Fixes cross-source scoring when predictions were set with one datasource and results come from another.
- Fix PandaScore tournament_id filtering — server-side filter[tournament_id] is unreliable for finished matches; now uses filter[serie_id] + client-side filtering via tournament_id field in each match object.
- Add tournament_id to PandaScore config, PandaScoreFetcher, NewPoller, and configure script (-tournament-id flag) so a single stage can be targeted within a multi-stage series.
- Fix docker-compose.yml env loading — switch from env_file directive to volume-mounting .env so godotenv parses the KEY = "value" format correctly.