### PR TITLE
Fix: Upcoming matches not displaying in chronological order and Leaderboard not updating when $set called

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -7,6 +7,7 @@
 package app
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -18,6 +19,7 @@ import (
 	"pickems-bot/sources"
 	"pickems-bot/store"
 	"pickems-bot/tournament"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -404,6 +406,11 @@ func (a *App) GetUpcomingMatches() ([]sources.ScheduledMatch, error) {
 		}
 		matches = append(matches, match)
 	}
+
+	slices.SortFunc(matches, func(a, b sources.ScheduledMatch) int {
+		return cmp.Compare(a.EpochTime, b.EpochTime)
+	})
+
 	return matches, nil
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -95,6 +95,7 @@ func (a *App) Allow() bool {
 // It receives a user struct that contains userID and userName, and a list of teams the user wishes to set,
 // and strings containing dbName, collName and round.
 // It updates the user's predictions in the database, or returns an error if it occurs.
+// As a side effect, a successful set also triggers the leaderboard being updated
 func (a *App) SetUserPrediction(user models.User, inputTeams []string, round string) error {
 	err := a.Store.EnsureScheduledMatches()
 	if err != nil {
@@ -158,6 +159,13 @@ func (a *App) SetUserPrediction(user models.User, inputTeams []string, round str
 	if err != nil {
 		return err
 	}
+
+	// Update the leaderboard with the new user's prediction
+	go func() {
+		if err := a.GenerateLeaderboard(); err != nil {
+			a.logger().Error("leaderboard regen after set failed", "error", err)
+		}
+	}()
 
 	return nil
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -796,6 +796,48 @@ func TestGetUpcomingMatches_FiltersFinishedMatches(t *testing.T) {
 	}
 }
 
+func TestGetUpcomingMatches_DisplaysInChronologicalOrder(t *testing.T) {
+	mockStore := NewMockStore("swiss", "test_round")
+
+	time1 := time.Now().Add(24 * time.Hour).Unix()
+	match1 := sources.ScheduledMatch{
+		Team1:     "Team A",
+		Team2:     "Team B",
+		BestOf:    "3",
+		EpochTime: time1,
+		StreamURL: "BLAST",
+		Finished:  false,
+	}
+
+	time2 := time.Now().Add(25 * time.Hour).Unix()
+	match2 := sources.ScheduledMatch{
+		Team1:     "Team C",
+		Team2:     "Team D",
+		BestOf:    "3",
+		EpochTime: time2,
+		StreamURL: "BLAST",
+		Finished:  false,
+	}
+
+	mockStore.SetScheduledMatches([]sources.ScheduledMatch{match1, match2})
+
+	api := &App{Store: mockStore}
+
+	matches, err := api.GetUpcomingMatches()
+	if err != nil {
+		t.Errorf("Expected no error, got: %s", err.Error())
+	}
+
+	if len(matches) != 2 {
+		t.Error("Expected exactly 2 matches to be seeded")
+	}
+
+	if matches[0].EpochTime > matches[1].EpochTime {
+		t.Error("Expected matches to be sorted chronologically")
+	}
+
+}
+
 // endregion
 
 // region GetTournamentInfo tests

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -459,6 +459,37 @@ func TestGetLeaderboard_NoLeaderboard(t *testing.T) {
 	}
 }
 
+func TestSetUserPrediction_TriggersLeaderboardRegen(t *testing.T) {
+	mockStore := NewMockStore("swiss", "test_round")
+	mockStore.SetScheduledMatches([]sources.ScheduledMatch{{Team1: "Team A", Team2: "Team B"}})
+	mockStore.LeaderboardStored = make(chan struct{}, 1)
+
+	// Seed a prediction so GenerateLeaderboard has something to work with
+	mockStore.Predictions["user1"] = models.Prediction{
+		UserID: "user1", Username: "player1",
+		Format: "swiss", Round: "test_round",
+		Win:     []string{"Team A", "Team B"},
+		Advance: []string{"Team C", "Team D", "Team E", "Team F", "Team G", "Team H"},
+		Lose:    []string{"Team I", "Team J"},
+	}
+
+	api := &App{Store: mockStore}
+	user := models.User{UserID: "user1", Username: "player1"}
+	teams := []string{"Team A", "Team B", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
+
+	err := api.SetUserPrediction(user, teams, "test_round")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	select {
+	case <-mockStore.LeaderboardStored:
+		// leaderboard was regenerated
+	case <-time.After(time.Second):
+		t.Fatal("leaderboard was not regenerated after successful set")
+	}
+}
+
 // endregion
 
 // region GetTeams tests

--- a/app/test_mocks.go
+++ b/app/test_mocks.go
@@ -54,7 +54,8 @@ type MockStore struct {
 	MatchKind  tournament.Kind
 
 	// Leaderboard storage
-	Leaderboard []store.LeaderboardEntry
+	Leaderboard       []store.LeaderboardEntry
+	LeaderboardStored chan struct{}
 
 	// Database and Round info
 	DatabaseName string
@@ -272,6 +273,12 @@ func (m *MockStore) StoreLeaderboard(leaderboard store.Leaderboard) error {
 		return m.StoreLeaderboardError
 	}
 	m.Leaderboard = leaderboard.Entries
+	if m.LeaderboardStored != nil {
+		select {
+		case m.LeaderboardStored <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes a couple of bugs:

## Upcoming match displays in reverse order
Closes #54 
Previously upcoming matches were not sorted chronologically, we relied on the data source returning them in the correct order. This PR adds a simple sort function in `GetUpcomingMatches()` that sorts on match time. Added test to verify behaviour and running the test bot confirmed behaviour

## Leaderboard does not update with $set command
Closes #56 
Added `GenerateLeaderboard()` goroutine to `SetUserPrediction()` after an insert to the db. Only fires on a successful insert. Regenerates the leaderboard on `$set` so that a user see's themselves on the leaderboard straight away, instead of waiting for a match update to occur. Added test coverage