### PR TITLE
Improve set command functionality

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -140,12 +140,15 @@ func (a *App) SetUserPrediction(user models.User, inputTeams []string, round str
 	}
 
 	// Check for unique team names
-	seen := make(map[string]bool)
-	for _, team := range teams {
-		if seen[team] {
-			return models.Prediction{}, fmt.Errorf("'%s' entered multiple times, stored prediction was not updated", team)
+	seen := make(map[string]string)
+	for i, team := range teams {
+		if original, exists := seen[team]; exists {
+			if original == inputTeams[i] {
+				return models.Prediction{}, fmt.Errorf("'%s' entered multiple times, stored prediction was not updated", team)
+			}
+			return models.Prediction{}, fmt.Errorf("'%s' and '%s' both resolved to '%s'. Please enter a more specific name for one of them", original, inputTeams[i], team)
 		}
-		seen[team] = true
+		seen[team] = inputTeams[i]
 	}
 
 	// Generate prediction struct

--- a/app/app.go
+++ b/app/app.go
@@ -96,21 +96,21 @@ func (a *App) Allow() bool {
 // and strings containing dbName, collName and round.
 // It updates the user's predictions in the database, or returns an error if it occurs.
 // As a side effect, a successful set also triggers the leaderboard being updated
-func (a *App) SetUserPrediction(user models.User, inputTeams []string, round string) error {
+func (a *App) SetUserPrediction(user models.User, inputTeams []string, round string) (models.Prediction, error) {
 	err := a.Store.EnsureScheduledMatches()
 	if err != nil {
-		return err
+		return models.Prediction{}, err
 	}
 
 	// Get valid team names
 	validTeams, formatName, err := a.Store.GetValidTeams()
 	if err != nil {
-		return err
+		return models.Prediction{}, err
 	}
 
 	f, err := tournament.Get(formatName)
 	if err != nil {
-		return fmt.Errorf("unknown tournament format: %s", formatName)
+		return models.Prediction{}, fmt.Errorf("unknown tournament format: %s", formatName)
 	}
 
 	// Get number of required teams
@@ -118,7 +118,7 @@ func (a *App) SetUserPrediction(user models.User, inputTeams []string, round str
 
 	// Check num required teams is correct
 	if len(inputTeams) != requiredPredictions {
-		return fmt.Errorf("incorrect number of teams arguments, expected %d but got %d", requiredPredictions, len(inputTeams))
+		return models.Prediction{}, fmt.Errorf("incorrect number of teams arguments, expected %d but got %d", requiredPredictions, len(inputTeams))
 	}
 
 	// Fix formatting on input teams
@@ -136,14 +136,14 @@ func (a *App) SetUserPrediction(user models.User, inputTeams []string, round str
 		for i := range invalidTeams {
 			str.WriteString(fmt.Sprintf(" '%s'", invalidTeams[i]))
 		}
-		return errors.New(str.String())
+		return models.Prediction{}, errors.New(str.String())
 	}
 
 	// Check for unique team names
 	seen := make(map[string]bool)
 	for _, team := range teams {
 		if seen[team] {
-			return fmt.Errorf("'%s' entered multiple times, stored prediction was not updated", team)
+			return models.Prediction{}, fmt.Errorf("'%s' entered multiple times, stored prediction was not updated", team)
 		}
 		seen[team] = true
 	}
@@ -151,13 +151,13 @@ func (a *App) SetUserPrediction(user models.User, inputTeams []string, round str
 	// Generate prediction struct
 	prediction, err := f.GeneratePrediction(user, round, teams)
 	if err != nil {
-		return err
+		return models.Prediction{}, err
 	}
 
 	// Insert prediction to db
 	err = a.Store.StoreUserPrediction(user.UserID, prediction)
 	if err != nil {
-		return err
+		return models.Prediction{}, err
 	}
 
 	// Update the leaderboard with the new user's prediction
@@ -167,7 +167,7 @@ func (a *App) SetUserPrediction(user models.User, inputTeams []string, round str
 		}
 	}()
 
-	return nil
+	return prediction, nil
 }
 
 // CheckPrediction contains the logic required to check a prediction.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -132,6 +132,26 @@ func TestSetUserPrediction_DuplicateTeams(t *testing.T) {
 	}
 }
 
+func TestSetUserPrediction_FuzzyCollision(t *testing.T) {
+	mockStore := NewMockStore("swiss", "test_round")
+	mockStore.SetScheduledMatches([]sources.ScheduledMatch{{Team1: "Team A", Team2: "Team B"}})
+
+	api := &App{Store: mockStore}
+
+	user := models.User{UserID: "user1", Username: "testuser"}
+	// "Team A" and "team a" are different inputs that both fuzzy-resolve to "Team A"
+	teams := []string{"Team A", "team a", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
+
+	_, err := api.SetUserPrediction(user, teams, "test_round")
+	if err == nil {
+		t.Error("Expected error for fuzzy collision, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "both resolved to") {
+		t.Errorf("Expected error about fuzzy collision, got: %s", err.Error())
+	}
+}
+
 func TestSetUserPrediction_NoScheduledMatches(t *testing.T) {
 	mockStore := NewMockStore("swiss", "test_round")
 	// Don't set scheduled matches

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -43,7 +43,7 @@ func TestSetUserPrediction_SwissFormat_Success(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "testuser"}
 	teams := []string{"Team A", "Team B", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err != nil {
 		t.Errorf("Expected no error, got: %s", err.Error())
 	}
@@ -69,7 +69,7 @@ func TestSetUserPrediction_SingleEliminationFormat_Success(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "testuser"}
 	teams := []string{"Team A", "Team B", "Team C", "Team D"} // 4 teams for 8-team bracket
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err != nil {
 		t.Errorf("Expected no error, got: %s", err.Error())
 	}
@@ -84,7 +84,7 @@ func TestSetUserPrediction_WrongNumberOfTeams(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "testuser"}
 	teams := []string{"Team A", "Team B"} // Only 2 teams, need 10 for Swiss
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err == nil {
 		t.Error("Expected error for wrong number of teams, got nil")
 	}
@@ -103,7 +103,7 @@ func TestSetUserPrediction_InvalidTeamNames(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "testuser"}
 	teams := []string{"Invalid1", "Invalid2", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err == nil {
 		t.Error("Expected error for invalid team names, got nil")
 	}
@@ -122,7 +122,7 @@ func TestSetUserPrediction_DuplicateTeams(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "testuser"}
 	teams := []string{"Team A", "Team A", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err == nil {
 		t.Error("Expected error for duplicate teams, got nil")
 	}
@@ -141,7 +141,7 @@ func TestSetUserPrediction_NoScheduledMatches(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "testuser"}
 	teams := []string{"Team A", "Team B", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err == nil {
 		t.Error("Expected error when no scheduled matches exist, got nil")
 	}
@@ -157,7 +157,7 @@ func TestSetUserPrediction_StoreError(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "testuser"}
 	teams := []string{"Team A", "Team B", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err == nil {
 		t.Error("Expected error from store, got nil")
 	}
@@ -477,7 +477,7 @@ func TestSetUserPrediction_TriggersLeaderboardRegen(t *testing.T) {
 	user := models.User{UserID: "user1", Username: "player1"}
 	teams := []string{"Team A", "Team B", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H", "Team I", "Team J"}
 
-	err := api.SetUserPrediction(user, teams, "test_round")
+	_, err := api.SetUserPrediction(user, teams, "test_round")
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}

--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -137,7 +137,7 @@ func (b *Bot) setPredictionsHandler(session DiscordSession, message *discordgo.M
 	msg, _ := spaceSplitter.Split(message.Content)
 	userPreds := msg[1:]
 
-	err := b.APIPtr.SetUserPrediction(user, userPreds, b.APIPtr.Store.GetRound())
+	prediction, err := b.APIPtr.SetUserPrediction(user, userPreds, b.APIPtr.Store.GetRound())
 	if err != nil {
 		b.logger().Error("failed to set user prediction", "user", user.Username, "error", fmt.Errorf("setPredictionsHandler: %w", err))
 		sendError(session, message.ChannelID, err.Error())
@@ -148,6 +148,11 @@ func (b *Bot) setPredictionsHandler(session DiscordSession, message *discordgo.M
 		Title:       "Pick'Ems Updated",
 		Description: fmt.Sprintf("%s's Pick'Ems have been saved.", user.Username),
 		Color:       green,
+		Fields: []*discordgo.MessageEmbedField{
+			{Name: "3-0", Value: strings.Join(prediction.Win, ", "), Inline: false},
+			{Name: "Advance", Value: strings.Join(prediction.Advance, ", "), Inline: false},
+			{Name: "0-3", Value: strings.Join(prediction.Lose, ", "), Inline: false},
+		},
 	}
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
 		b.logger().Error("failed to send set-predictions embed", "error", fmt.Errorf("setPredictionsHandler: %w", err))

--- a/bot/handlers_test.go
+++ b/bot/handlers_test.go
@@ -336,19 +336,40 @@ func TestLeaderboard_Success(t *testing.T) {
 func TestSetPredictions_Swiss_Success(t *testing.T) {
 	bot := createTestBot("swiss")
 	mockSession := NewMockDiscordSession()
-	// Swiss format requires 10 teams: 2 3-0, 6 advance, 2 0-3
+	// 10 unique valid teams: positions 0-1 → 3-0, 2-7 → Advance, 8-9 → 0-3
 	message := createMockMessage(
-		"$set \"Team A\" \"Team B\" \"Team C\" \"Team D\" \"Team E\" \"Team F\" \"Team A\" \"Team B\" \"Team C\" \"Team D\"",
+		"$set \"Team A\" \"Team B\" \"Team C\" \"Team D\" \"Team E\" \"Team F\" \"Team G\" \"Team H\" \"Team I\" \"Team J\"",
 		"user123", "TestUser", "channel123",
 	)
 
 	bot.setPredictionsHandler(mockSession, message)
 
-	require.Len(t, mockSession.SentMessages, 1)
-	msg := mockSession.GetLastMessage()
-	assert.Equal(t, "channel123", msg.ChannelID)
-	// Should either succeed or give meaningful error
-	assert.NotEmpty(t, msg.Content)
+	require.Len(t, mockSession.SentEmbeds, 1)
+	embed := mockSession.GetLastEmbed().Embed
+	assert.Equal(t, "channel123", mockSession.GetLastEmbed().ChannelID)
+	assert.Equal(t, "Pick'Ems Updated", embed.Title)
+	assert.Contains(t, embed.Description, "TestUser")
+}
+
+func TestSetPredictions_Swiss_EmbedFieldsMatchPrediction(t *testing.T) {
+	bot := createTestBot("swiss")
+	mockSession := NewMockDiscordSession()
+	message := createMockMessage(
+		"$set \"Team A\" \"Team B\" \"Team C\" \"Team D\" \"Team E\" \"Team F\" \"Team G\" \"Team H\" \"Team I\" \"Team J\"",
+		"user123", "TestUser", "channel123",
+	)
+
+	bot.setPredictionsHandler(mockSession, message)
+
+	require.Len(t, mockSession.SentEmbeds, 1)
+	fields := mockSession.GetLastEmbed().Embed.Fields
+	require.Len(t, fields, 3)
+	assert.Equal(t, "3-0", fields[0].Name)
+	assert.Equal(t, "Team A, Team B", fields[0].Value)
+	assert.Equal(t, "Advance", fields[1].Name)
+	assert.Equal(t, "Team C, Team D, Team E, Team F, Team G, Team H", fields[1].Value)
+	assert.Equal(t, "0-3", fields[2].Name)
+	assert.Equal(t, "Team I, Team J", fields[2].Value)
 }
 
 func TestSetPredictions_InvalidInput(t *testing.T) {


### PR DESCRIPTION
This PR closes #55 by 
- Displaying what the user's set predictions are when calling `$set`. This eliminates the need to immediately call `$check` to verify they were set correctly
- Updated the error message for fuzzy match conflicts so it is more transparent what is happening instead of returning "<team name> entered multiple times". The original error message still remains for if a user legitimately enters the same value twice
- Updated tests / added new tests for both use cases