### PR TITLE
fix: make $set embed format-aware for single-elimination

### DIFF
--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -145,19 +145,37 @@ func (b *Bot) setPredictionsHandler(session DiscordSession, message *discordgo.M
 		return
 	}
 
+	fields, err := predictionFields(prediction)
+	if err != nil {
+		b.logger().Error("failed to build prediction fields", "user", user.Username, "error", fmt.Errorf("setPredictionsHandler: %w", err))
+		sendError(session, message.ChannelID, "An error occurred displaying your Pick'Ems.")
+		return
+	}
 	embed := &discordgo.MessageEmbed{
 		Title:       "Pick'Ems Updated",
 		Description: fmt.Sprintf("%s's Pick'Ems have been saved.", user.Username),
 		Color:       green,
-		Fields: []*discordgo.MessageEmbedField{
-			{Name: "3-0", Value: strings.Join(prediction.Win, ", "), Inline: false},
-			{Name: "Advance", Value: strings.Join(prediction.Advance, ", "), Inline: false},
-			{Name: "0-3", Value: strings.Join(prediction.Lose, ", "), Inline: false},
-		},
+		Fields:      fields,
 	}
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, embed); err != nil {
 		b.logger().Error("failed to send set-predictions embed", "error", fmt.Errorf("setPredictionsHandler: %w", err))
 	}
+}
+
+func predictionFields(p models.Prediction) ([]*discordgo.MessageEmbedField, error) {
+	f, err := tournament.Get(tournament.Kind(p.Format))
+	if err != nil {
+		return nil, fmt.Errorf("unknown prediction format %q", p.Format)
+	}
+	pFields, err := f.PredictionFields(p)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*discordgo.MessageEmbedField, len(pFields))
+	for i, pf := range pFields {
+		out[i] = &discordgo.MessageEmbedField{Name: pf.Name, Value: pf.Value}
+	}
+	return out, nil
 }
 
 // checkPredictionsHandler handles the $check command with a DiscordSession interface

--- a/bot/handlers_test.go
+++ b/bot/handlers_test.go
@@ -372,6 +372,75 @@ func TestSetPredictions_Swiss_EmbedFieldsMatchPrediction(t *testing.T) {
 	assert.Equal(t, "Team I, Team J", fields[2].Value)
 }
 
+func TestSetPredictions_SingleElim_EmbedFieldsMatchPrediction(t *testing.T) {
+	// 8-team playoff store: ValidTeams must contain all 8 teams so
+	// RequiredPredictions(8) = 4 passes the count check.
+	mockStore := app.NewMockStore(tournament.SingleElim, "Playoffs")
+	mockStore.SetEliminationResults(map[string]models.TeamProgress{
+		"Team A": {Round: "Quarter Final", Status: "eliminated"},
+		"Team B": {Round: "Quarter Final", Status: "eliminated"},
+		"Team C": {Round: "Quarter Final", Status: "eliminated"},
+		"Team D": {Round: "Quarter Final", Status: "eliminated"},
+		"Team E": {Round: "Semi Final", Status: "eliminated"},
+		"Team F": {Round: "Semi Final", Status: "eliminated"},
+		"Team G": {Round: "Grand Final", Status: "eliminated"},
+		"Team H": {Round: "Grand Final", Status: "advanced"},
+	})
+	mockStore.SetScheduledMatches([]sources.ScheduledMatch{
+		{Team1: "Team A", Team2: "Team B", BestOf: "3", EpochTime: 1700000000},
+	})
+	bot := &Bot{BotToken: "test_token", APIPtr: &app.App{Store: mockStore}}
+	mockSession := NewMockDiscordSession()
+	// 4 picks required (8 valid teams / 2); worst→best order so "Team D" becomes champion
+	message := createMockMessage(
+		"$set \"Team A\" \"Team B\" \"Team C\" \"Team D\"",
+		"user123", "TestUser", "channel123",
+	)
+
+	bot.setPredictionsHandler(mockSession, message)
+
+	require.Len(t, mockSession.SentEmbeds, 1)
+	fields := mockSession.GetLastEmbed().Embed.Fields
+	require.GreaterOrEqual(t, len(fields), 3)
+	assert.Equal(t, "Champion", fields[0].Name)
+	assert.Equal(t, "Team D", fields[0].Value)
+	assert.Equal(t, "Grand Final", fields[1].Name)
+	assert.Equal(t, "Team C", fields[1].Value)
+	assert.Equal(t, "Semi Final", fields[2].Name)
+	assert.Contains(t, fields[2].Value, "Team A")
+	assert.Contains(t, fields[2].Value, "Team B")
+}
+
+func TestPredictionFields_UnknownFormat(t *testing.T) {
+	_, err := predictionFields(models.Prediction{Format: "unknown-format"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown prediction format")
+}
+
+func TestPredictionFields_SwissMalformed(t *testing.T) {
+	_, err := predictionFields(models.Prediction{
+		Format: string(tournament.Swiss),
+		Win:    []string{"Team A"},
+		Progression: map[string]models.TeamProgress{
+			"Team B": {Round: "Grand Final", Status: "advanced"},
+		},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected progression data")
+}
+
+func TestPredictionFields_SingleElimMalformed(t *testing.T) {
+	_, err := predictionFields(models.Prediction{
+		Format: string(tournament.SingleElim),
+		Win:    []string{"Team A"},
+		Progression: map[string]models.TeamProgress{
+			"Team B": {Round: "Grand Final", Status: "advanced"},
+		},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected swiss data")
+}
+
 func TestSetPredictions_InvalidInput(t *testing.T) {
 	bot := createTestBot("swiss")
 	mockSession := NewMockDiscordSession()

--- a/models/models.go
+++ b/models/models.go
@@ -39,6 +39,13 @@ type Prediction struct {
 	Progression map[string]TeamProgress `bson:"progression,omitempty"`
 }
 
+// PredictionField is a format-agnostic name/value pair used to display a
+// prediction summary (e.g. in a Discord embed).
+type PredictionField struct {
+	Name  string
+	Value string
+}
+
 // ScoreResult represents the result of scoring a user's predictions.
 type ScoreResult struct {
 	Successes int `bson:"successes"`

--- a/tournament/format.go
+++ b/tournament/format.go
@@ -61,6 +61,11 @@ type Format interface {
 	// Scoring
 	CalculateScore(p models.Prediction, r MatchResult) (ScoreReport, error)
 
+	// PredictionFields returns a format-specific summary of p suitable for
+	// display (e.g. Discord embed fields). Returns an error if the prediction
+	// is malformed for this format (e.g. wrong field set populated).
+	PredictionFields(p models.Prediction) ([]models.PredictionField, error)
+
 	// DB Interaction
 	DecodeBSON(bytes []byte) (MatchResult, error)
 

--- a/tournament/single_elimination.go
+++ b/tournament/single_elimination.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 
 	"pickems-bot/models"
 	"pickems-bot/sources"
@@ -68,6 +69,36 @@ func (singleElimFormat) Name() Kind { return SingleElim }
 // RequiredPredictions returns teamCount / 2 — one pick per first-round
 // matchup, predicting which team advances.
 func (singleElimFormat) RequiredPredictions(teamCount int) int { return teamCount / 2 }
+
+func (singleElimFormat) PredictionFields(p models.Prediction) ([]models.PredictionField, error) {
+	if len(p.Win) > 0 || len(p.Advance) > 0 || len(p.Lose) > 0 {
+		return nil, fmt.Errorf("single-elimination prediction contains unexpected swiss data")
+	}
+	if len(p.Progression) == 0 {
+		return nil, fmt.Errorf("single-elimination prediction has no progression data")
+	}
+	roundOrder := []string{"Grand Final", "Semi Final", "Quarter Final", "Best of 16", "Best of 32"}
+	roundTeams := make(map[string][]string)
+	champion := ""
+	for team, prog := range p.Progression {
+		if prog.Status == "advanced" {
+			champion = team
+		} else {
+			roundTeams[prog.Round] = append(roundTeams[prog.Round], team)
+		}
+	}
+	var fields []models.PredictionField
+	if champion != "" {
+		fields = append(fields, models.PredictionField{Name: "Champion", Value: champion})
+	}
+	for _, round := range roundOrder {
+		if teams, ok := roundTeams[round]; ok {
+			slices.Sort(teams)
+			fields = append(fields, models.PredictionField{Name: round, Value: strings.Join(teams, ", ")})
+		}
+	}
+	return fields, nil
+}
 
 func (singleElimFormat) GeneratePrediction(user models.User, round string, teams []string) (models.Prediction, error) {
 	// Set generic attributes for Prediction struct

--- a/tournament/single_elimination_test.go
+++ b/tournament/single_elimination_test.go
@@ -11,6 +11,7 @@ import (
 	"pickems-bot/sources"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSingleElimCalculateScore_AllSucceeded tests a fully-correct prediction.
@@ -388,6 +389,50 @@ func TestGetEliminationResults_EmptyTeamNames(t *testing.T) {
 	assert.Equal(t, "Grand Final", results["TeamB"].Round)
 	assert.Equal(t, "advanced", results["TeamB"].Status)
 }
+
+// region PredictionFields
+
+// TestSingleElim_PredictionFields_HappyPath checks correct grouping for an 8-team bracket.
+// Input order is worst→best, so "Team H" (last) becomes champion.
+func TestSingleElim_PredictionFields_HappyPath(t *testing.T) {
+	// GeneratePrediction produces the Progression map from ordered input.
+	p, err := singleElimFormat{}.GeneratePrediction(
+		models.User{UserID: "u1", Username: "tester"}, "Playoffs",
+		[]string{"Team A", "Team B", "Team C", "Team D", "Team E", "Team F", "Team G", "Team H"},
+	)
+	require.NoError(t, err)
+
+	fields, err := singleElimFormat{}.PredictionFields(p)
+	assert.NoError(t, err)
+	require.GreaterOrEqual(t, len(fields), 3)
+	assert.Equal(t, "Champion", fields[0].Name)
+	assert.Equal(t, "Team H", fields[0].Value)
+	// Grand Final eliminated (runner-up)
+	assert.Equal(t, "Grand Final", fields[1].Name)
+	assert.Equal(t, "Team G", fields[1].Value)
+	// Semi Final
+	assert.Equal(t, "Semi Final", fields[2].Name)
+	assert.Contains(t, fields[2].Value, "Team E")
+	assert.Contains(t, fields[2].Value, "Team F")
+}
+
+func TestSingleElim_PredictionFields_EmptyProgression(t *testing.T) {
+	_, err := singleElimFormat{}.PredictionFields(models.Prediction{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no progression data")
+}
+
+func TestSingleElim_PredictionFields_MalformedHasSwissData(t *testing.T) {
+	p := models.Prediction{
+		Win:         []string{"Team A"},
+		Progression: map[string]models.TeamProgress{"Team B": {Round: "Grand Final", Status: "advanced"}},
+	}
+	_, err := singleElimFormat{}.PredictionFields(p)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected swiss data")
+}
+
+// endregion
 
 // endregion
 

--- a/tournament/swiss.go
+++ b/tournament/swiss.go
@@ -106,6 +106,17 @@ func (swissFormat) Name() Kind { return Swiss }
 // the real bracket exactly.
 func (swissFormat) RequiredPredictions(teamCount int) int { return 5 * teamCount / 8 }
 
+func (swissFormat) PredictionFields(p models.Prediction) ([]models.PredictionField, error) {
+	if len(p.Progression) > 0 {
+		return nil, fmt.Errorf("swiss prediction contains unexpected progression data")
+	}
+	return []models.PredictionField{
+		{Name: "3-0", Value: strings.Join(p.Win, ", ")},
+		{Name: "Advance", Value: strings.Join(p.Advance, ", ")},
+		{Name: "0-3", Value: strings.Join(p.Lose, ", ")},
+	}, nil
+}
+
 func (swissFormat) GeneratePrediction(user models.User, round string, teams []string) (models.Prediction, error) {
 	// Set generic attributes for Prediction struct
 	prediction := models.Prediction{

--- a/tournament/swiss_test.go
+++ b/tournament/swiss_test.go
@@ -14,6 +14,7 @@ import (
 	"pickems-bot/sources"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // region setSwissPredictions
@@ -313,6 +314,37 @@ func TestNormalizeSwissSections(t *testing.T) {
 		got := NormalizeSwissSections(nodes)
 		assert.Equal(t, c.want, got[0].Section, "input: %q", c.input)
 	}
+}
+
+// endregion
+
+// region PredictionFields
+
+func TestSwiss_PredictionFields_HappyPath(t *testing.T) {
+	p := models.Prediction{
+		Win:     []string{"Team A"},
+		Advance: []string{"Team B", "Team C", "Team D"},
+		Lose:    []string{"Team E"},
+	}
+	fields, err := swissFormat{}.PredictionFields(p)
+	assert.NoError(t, err)
+	require.Len(t, fields, 3)
+	assert.Equal(t, "3-0", fields[0].Name)
+	assert.Equal(t, "Team A", fields[0].Value)
+	assert.Equal(t, "Advance", fields[1].Name)
+	assert.Equal(t, "Team B, Team C, Team D", fields[1].Value)
+	assert.Equal(t, "0-3", fields[2].Name)
+	assert.Equal(t, "Team E", fields[2].Value)
+}
+
+func TestSwiss_PredictionFields_MalformedHasProgression(t *testing.T) {
+	p := models.Prediction{
+		Win:         []string{"Team A"},
+		Progression: map[string]models.TeamProgress{"Team B": {Round: "Grand Final", Status: "advanced"}},
+	}
+	_, err := swissFormat{}.PredictionFields(p)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected progression data")
 }
 
 // endregion


### PR DESCRIPTION
## Summary

- The `$set` confirmation embed was always rendering `3-0 / Advance / 0-3` fields, which are empty for single-elimination predictions (those use `Progression` instead)
- Adds `PredictionFields(models.Prediction) ([]models.PredictionField, error)` to the `Format` interface — each format owns its display logic and the compiler enforces it for any new format added in future
- Swiss implementation validates no `Progression` is present; SingleElim validates no Swiss fields are present — errors on malformed documents rather than silently forcing the wrong format
- Handler delegates to the interface via `prediction.Format`, converting the result to Discord embed fields

## Test plan

- [x] `TestSwiss_PredictionFields_HappyPath` — correct 3-0/Advance/0-3 fields returned
- [x] `TestSwiss_PredictionFields_MalformedHasProgression` — errors when Progression unexpectedly set
- [x] `TestSingleElim_PredictionFields_HappyPath` — Champion/Grand Final/Semi Final fields returned in round order
- [x] `TestSingleElim_PredictionFields_EmptyProgression` — errors on empty Progression
- [x] `TestSingleElim_PredictionFields_MalformedHasSwissData` — errors when Swiss fields unexpectedly set
- [x] `TestSetPredictions_SingleElim_EmbedFieldsMatchPrediction` — handler integration test for SingleElim embed
- [x] `TestPredictionFields_UnknownFormat` / `_SwissMalformed` / `_SingleElimMalformed` — handler helper error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)