### PR TITLE
Migrate cron scrapers in-process + tournament format detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@
 - `set-tournament` takes a tournament and a round, both autocompleted. The tournament list shows distinct names, so a tournament split across several stages no longer appears multiple times; the round list is scoped to the rounds available for the chosen tournament.
 - `set-round` changes the round without re-picking the tournament, autocompleting only the rounds valid for the currently-configured tournament. Because each (tournament, round) stage is its own catalog row, switching round repoints the channel at the matching row.
 - Both commands resolve the (name, round) pair to a specific tournament row and store its id and round together, so `guild_config.round` always matches the selected stage rather than free-typed text.
-- `guild_config` is now seeded per channel by `/config`; every command that resolves tournament context reads it. The tournament catalog is populated independently (ingestion script), keeping `/config` source-agnostic across PandaScore and Liquipedia.
+- `guild_config` is now seeded per channel by `/config`; every command that resolves tournament context reads it. The tournament catalog is populated independently (the ingest jobs, below), keeping `/config` source-agnostic across PandaScore and Liquipedia.
 - Store: `EnsureGuild`, `ListTournamentNames`, `ListRoundsForTournament`, `GetTournamentByNameAndRound`, `GetTournament`. App: `GetConfig`, `SetConfigTournament`, `SetConfigRound`, `ListTournamentNames`, `ListRoundsForTournament`, `RoundsForConfiguredTournament`.
+
+In-process data ingestion (`ingest` package):
+- The standalone data-seeding scripts (`scripts/dataseeding`) were folded into the app and now run as background goroutines launched from `main.go`, each on its own schedule.
+- `TournamentSync` (hourly) refreshes the tournament catalog from PandaScore's upcoming + running endpoints, upserting active tournaments and sweeping any that dropped out of the active set to `is_finished`. It gates each request on the app's PandaScore rate limiter (`App.Wait`), so it and the live poller share one API budget.
+- `VRSSync` (hourly) refreshes the VRS world rankings from the public GitHub snapshot, no-opping when the snapshot date is unchanged.
+- Fetch/parse moved into `sources` (`GetUpcomingPandaScoreTournaments`, `GetRunningPandaScoreTournaments`, `FetchLatestVRSStandings`, `ParseVRSStandings`); DB writes into `store` (`SyncTournaments`, `SyncStandings`). `App.Wait` was added alongside `App.Allow` (blocking vs non-blocking on the shared limiter, so batch jobs pace instead of drop).
+
+Tournament format detection:
+- A tournament's format (swiss / single-elimination / double-elimination / other) is now detected from its PandaScore bracket structure rather than match-name text: any loser-bracket feeder edge means double-elimination, winner-only edges mean single-elimination, and no bracket edges means a group stage (round-robin when the match count is n*(n-1)/2, otherwise swiss). Detection runs best-effort in the background when a tournament is configured via `/config`, and the result is stored on the tournament row.
+- Formats that can't run predictions (double-elimination, other) are now first-class via a null-object format: read-only features (schedule, results) keep working, while `/set` refuses cleanly with "the selected tournament uses a format that does not support predictions" instead of erroring on an unknown format.
+- Store: `SetTournamentFormat`, and `Tournament` now carries all row columns. Sources: `GetPandaScoreBracket`, `CountTeams`. Tournament: `DetectKindFromBracket`, the `Other` kind, and `ErrPredictionsUnsupported`.
 
 ## 3.7
 - fix: sort upcoming matches chronologically in `$upcoming`

--- a/app/app.go
+++ b/app/app.go
@@ -23,6 +23,7 @@ import (
 	"pickems-bot/tournament"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -491,12 +492,15 @@ func (a *App) SetConfigTournament(ctx context.Context, guildID, channelID, name,
 	if err != nil {
 		return store.Tournament{}, fmt.Errorf("SetConfigTournament: %w", err)
 	}
+
 	if err := a.upsertConfigField(ctx, guildID, channelID, func(c *store.GuildConfig) {
 		c.TournamentID = &t.ID
 		c.Round = &t.Round
 	}); err != nil {
 		return store.Tournament{}, err
 	}
+
+	go a.detectFormatAsync(t)
 	return t, nil
 }
 
@@ -552,12 +556,15 @@ func (a *App) SetConfigRound(ctx context.Context, guildID, channelID, round stri
 	if err != nil {
 		return store.Tournament{}, fmt.Errorf("SetConfigRound: %w", err)
 	}
+
 	if err := a.upsertConfigField(ctx, guildID, channelID, func(c *store.GuildConfig) {
 		c.TournamentID = &t.ID
 		c.Round = &t.Round
 	}); err != nil {
 		return store.Tournament{}, err
 	}
+
+	go a.detectFormatAsync(t)
 	return t, nil
 }
 
@@ -583,4 +590,46 @@ func (a *App) upsertConfigField(ctx context.Context, guildID, channelID string, 
 		return fmt.Errorf("upsertConfigField: %w", err)
 	}
 	return nil
+}
+
+// detectFormatAsync runs checkAndStoreFormat in the background after a config
+// change, logging (not returning) any failure. Detection waits on the shared
+// rate limiter and hits the network, so it must not block the Discord
+// interaction that triggered the config change. It uses a detached context
+// because the caller's request context may be cancelled once it responds.
+//
+// Consequence for the poller subscription pool (next v4 step): a just-configured
+// tournament may briefly have a NULL/undetected format, so the pool builder must
+// tolerate that (skip-and-log, or retry) rather than assume every configured
+// tournament already has a supported format.
+func (a *App) detectFormatAsync(t store.Tournament) {
+	if err := a.checkAndStoreFormat(context.Background(), t); err != nil {
+		a.logger().Warn("format detection failed",
+			"tournament_id", t.ID, "external_id", t.ExternalID, "error", err)
+	}
+}
+
+// checkAndStoreFormat fetches the PandaScore bracket for a tournament, infers its format kind, and persists that value in the db.
+func (a *App) checkAndStoreFormat(ctx context.Context, t store.Tournament) error {
+	if t.Source != "pandascore" || t.Format != nil {
+		return nil // only PandaScore has a format field, and it's already set
+	}
+
+	// external_id is stored as text but the bracket endpoint keys on the numeric
+	// PandaScore id; parse before spending a rate-limiter token.
+	extID, err := strconv.Atoi(t.ExternalID)
+	if err != nil {
+		return fmt.Errorf("checkAndStoreFormat: invalid external id %q: %w", t.ExternalID, err)
+	}
+
+	if err := a.Wait(ctx); err != nil {
+		return err
+	}
+
+	brackets, err := sources.GetPandaScoreBracket(os.Getenv("PANDASCORE_API_KEY"), extID)
+	if err != nil {
+		return fmt.Errorf("checkAndStoreFormat: %w", err)
+	}
+	kind := tournament.DetectKindFromBracket(brackets, sources.CountTeams(brackets))
+	return a.Store.SetTournamentFormat(ctx, t.ID, string(kind))
 }

--- a/app/app.go
+++ b/app/app.go
@@ -84,11 +84,24 @@ func NewApp(cfg config.Config, postgresURI string, log *slog.Logger) (*App, erro
 }
 
 // Allow calls the app's configured rate limiter's Allow() function.
+// Non-blocking: returns false immediately when no token is available. The poller
+// uses this to skip a tick rather than wait.
 func (a *App) Allow() bool {
 	if a.rateLimiter == nil {
 		return false
 	}
 	return a.rateLimiter.Allow()
+}
+
+// Wait blocks until the shared rate limiter permits another call, or ctx is
+// cancelled. Backed by the same limiter as Allow(), so background jobs that call
+// Wait and the poller that calls Allow() draw from one token bucket and together
+// stay within the API's rate limit. Batch jobs use this to pace instead of drop.
+func (a *App) Wait(ctx context.Context) error {
+	if a.rateLimiter == nil {
+		return nil
+	}
+	return a.rateLimiter.Wait(ctx)
 }
 
 // resolveConfig looks up the guild config and validates that a tournament and round are set.

--- a/app/test_mocks.go
+++ b/app/test_mocks.go
@@ -66,6 +66,10 @@ type MockStore struct {
 	SyncedStandings      []store.VRSEntry
 	SyncStandingsResult  bool
 	SyncStandingsError   error
+
+	SetFormatID              int
+	SetFormatValue           string
+	SetTournamentFormatError error
 }
 
 // NewMockStore creates a MockStore pre-wired for the given format and round.
@@ -184,6 +188,15 @@ func (m *MockStore) SyncTournaments(_ context.Context, active []store.Tournament
 		return m.SyncTournamentsError
 	}
 	m.SyncedTournaments = active
+	return nil
+}
+
+// SetTournamentFormat implements store.Interface, recording the last (id, format) set.
+func (m *MockStore) SetTournamentFormat(_ context.Context, id int, format string) error {
+	if m.SetTournamentFormatError != nil {
+		return m.SetTournamentFormatError
+	}
+	m.SetFormatID, m.SetFormatValue = id, format
 	return nil
 }
 

--- a/app/test_mocks.go
+++ b/app/test_mocks.go
@@ -60,6 +60,12 @@ type MockStore struct {
 	ListRoundsError             error
 	GetTournamentError          error
 	EnsureGuildError            error
+
+	SyncedTournaments    []store.TournamentCatalogEntry
+	SyncTournamentsError error
+	SyncedStandings      []store.VRSEntry
+	SyncStandingsResult  bool
+	SyncStandingsError   error
 }
 
 // NewMockStore creates a MockStore pre-wired for the given format and round.
@@ -170,6 +176,15 @@ func (m *MockStore) GetTournament(_ context.Context, id int) (store.Tournament, 
 		}
 	}
 	return store.Tournament{}, fmt.Errorf("tournament not found: id=%d", id)
+}
+
+// SyncTournaments implements store.Interface, recording the active set it was given.
+func (m *MockStore) SyncTournaments(_ context.Context, active []store.TournamentCatalogEntry) error {
+	if m.SyncTournamentsError != nil {
+		return m.SyncTournamentsError
+	}
+	m.SyncedTournaments = active
+	return nil
 }
 
 // EnsureScheduledMatches implements store.Interface.
@@ -304,6 +319,15 @@ func (m *MockStore) ListVRSRankings(ctx context.Context) ([]store.VRSEntry, erro
 		return nil, m.ListVRSRankingsError
 	}
 	return m.VRSEntries, nil
+}
+
+// SyncStandings implements store.Interface, recording the entries it was given.
+func (m *MockStore) SyncStandings(_ context.Context, entries []store.VRSEntry) (bool, error) {
+	if m.SyncStandingsError != nil {
+		return false, m.SyncStandingsError
+	}
+	m.SyncedStandings = entries
+	return m.SyncStandingsResult, nil
 }
 
 // --- Test setup helpers ---

--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -141,7 +141,7 @@ func (b *Bot) setInteractionHandler(session DiscordSession, i *discordgo.Interac
 			}},
 		}
 	default:
-		respondError(session, i.Interaction, "Unsupported tournament format.")
+		respondError(session, i.Interaction, "The selected tournament uses a format that does not support predictions.")
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.4
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/bwmarrin/discordgo v0.29.0
-	github.com/go-andiamo/splitter v1.2.5
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-andiamo/splitter v1.2.5 h1:P3NovWMY2V14TJJSolXBvlOmGSZo3Uz+LtTl2bsV/eY=
-github.com/go-andiamo/splitter v1.2.5/go.mod h1:8WHU24t9hcMKU5FXDQb1hysSEC/GPuivIp0uKY1J8gw=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/ingest/tournaments.go
+++ b/ingest/tournaments.go
@@ -1,0 +1,119 @@
+// Package ingest holds the background jobs that keep source-derived reference
+// data fresh: the tournament catalog (/config picklist) and the VRS rankings.
+// Each job runs on its own schedule as a goroutine launched from main, fetching
+// via sources and persisting via store.
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"pickems-bot/app"
+	"pickems-bot/sources"
+	"pickems-bot/store"
+)
+
+// TournamentSync periodically refreshes the tournament catalog (upcoming +
+// running PandaScore tournaments) that /config picks from. It shares the app's
+// PandaScore rate limiter via app.Wait, so its calls and the live-match poller's
+// draw from one token bucket and together stay within the API limit.
+type TournamentSync struct {
+	app      *app.App
+	apiKey   string
+	interval time.Duration
+	log      *slog.Logger
+}
+
+// NewTournamentSync constructs a TournamentSync. interval <= 0 defaults to one
+// hour; log may be nil (falls back to the slog default).
+func NewTournamentSync(a *app.App, apiKey string, interval time.Duration, log *slog.Logger) *TournamentSync {
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	var jobLog *slog.Logger
+	if log != nil {
+		jobLog = log.With("component", "ingest.tournaments")
+	}
+	return &TournamentSync{app: a, apiKey: apiKey, interval: interval, log: jobLog}
+}
+
+func (s *TournamentSync) logger() *slog.Logger {
+	if s.log == nil {
+		return slog.Default()
+	}
+	return s.log
+}
+
+// Start runs an immediate sync, then repeats every interval until ctx is cancelled.
+func (s *TournamentSync) Start(ctx context.Context) {
+	s.runOnce(ctx)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger().Info("tournament sync stopping", "reason", ctx.Err())
+			return
+		case <-ticker.C:
+			s.runOnce(ctx)
+		}
+	}
+}
+
+// runOnce fetches the active tournament set and syncs it to the catalog. Errors
+// are logged and swallowed so the job retries on the next tick.
+func (s *TournamentSync) runOnce(ctx context.Context) {
+	active, err := s.fetchActive(ctx)
+	if err != nil {
+		s.logger().Warn("tournament fetch failed, will retry next tick", "error", err)
+		return
+	}
+	if len(active) == 0 {
+		// An empty set almost always means a bad API response; syncing it would
+		// wrongly mark every catalog row finished, so skip rather than sweep.
+		s.logger().Warn("no active tournaments returned, skipping sync")
+		return
+	}
+	if err := s.app.Store.SyncTournaments(ctx, active); err != nil {
+		s.logger().Warn("tournament sync failed", "error", err)
+		return
+	}
+	s.logger().Info("tournament catalog synced", "count", len(active))
+}
+
+// fetchActive returns the combined upcoming + running tournament set, each fetch
+// gated on the shared rate limiter. Both fetches must succeed: a partial set
+// would make live tournaments look finished during the catalog sweep.
+func (s *TournamentSync) fetchActive(ctx context.Context) ([]store.TournamentCatalogEntry, error) {
+	if err := s.app.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("rate limiter wait: %w", err)
+	}
+	upcoming, err := sources.GetUpcomingPandaScoreTournaments(s.apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("fetch upcoming: %w", err)
+	}
+
+	if err := s.app.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("rate limiter wait: %w", err)
+	}
+	running, err := sources.GetRunningPandaScoreTournaments(s.apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("fetch running: %w", err)
+	}
+
+	all := append(upcoming, running...)
+	entries := make([]store.TournamentCatalogEntry, 0, len(all))
+	for _, t := range all {
+		entries = append(entries, store.TournamentCatalogEntry{
+			ExternalID: strconv.Itoa(t.ID),
+			Name:       t.DisplayName(),
+			Round:      t.Round,
+			SeriesID:   strconv.Itoa(t.SerieID),
+		})
+	}
+	return entries, nil
+}

--- a/ingest/vrs.go
+++ b/ingest/vrs.go
@@ -1,0 +1,116 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"pickems-bot/app"
+	"pickems-bot/sources"
+	"pickems-bot/store"
+)
+
+// vrsStandingsDateLayout matches the yyyy_mm_dd label in a VRS snapshot header.
+const vrsStandingsDateLayout = "2006_01_02"
+
+// VRSSync periodically refreshes the VRS world rankings from the public GitHub
+// snapshot. It hits GitHub, not PandaScore, so it does not use the PandaScore
+// rate limiter. Standings change slowly and the store no-ops when the snapshot
+// date is unchanged, so a modest interval is cheap.
+type VRSSync struct {
+	app      *app.App
+	interval time.Duration
+	log      *slog.Logger
+}
+
+// NewVRSSync constructs a VRSSync. interval <= 0 defaults to one hour; log may
+// be nil (falls back to the slog default).
+func NewVRSSync(a *app.App, interval time.Duration, log *slog.Logger) *VRSSync {
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	var jobLog *slog.Logger
+	if log != nil {
+		jobLog = log.With("component", "ingest.vrs")
+	}
+	return &VRSSync{app: a, interval: interval, log: jobLog}
+}
+
+func (s *VRSSync) logger() *slog.Logger {
+	if s.log == nil {
+		return slog.Default()
+	}
+	return s.log
+}
+
+// Start runs an immediate sync, then repeats every interval until ctx is cancelled.
+func (s *VRSSync) Start(ctx context.Context) {
+	s.runOnce(ctx)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger().Info("VRS sync stopping", "reason", ctx.Err())
+			return
+		case <-ticker.C:
+			s.runOnce(ctx)
+		}
+	}
+}
+
+// runOnce fetches, parses, and syncs the latest VRS snapshot. Errors are logged
+// and swallowed so the job retries on the next tick.
+func (s *VRSSync) runOnce(ctx context.Context) {
+	raw, err := sources.FetchLatestVRSStandings()
+	if err != nil {
+		s.logger().Warn("VRS fetch failed, will retry next tick", "error", err)
+		return
+	}
+
+	parsed := sources.ParseVRSStandings(raw)
+	if len(parsed) == 0 {
+		s.logger().Warn("VRS parse produced no standings, skipping sync")
+		return
+	}
+
+	entries, err := toStoreEntries(parsed)
+	if err != nil {
+		s.logger().Warn("VRS date parse failed, skipping sync", "error", err)
+		return
+	}
+
+	synced, err := s.app.Store.SyncStandings(ctx, entries)
+	if err != nil {
+		s.logger().Warn("VRS sync failed", "error", err)
+		return
+	}
+	if synced {
+		s.logger().Info("VRS standings synced", "count", len(entries))
+	} else {
+		s.logger().Info("VRS standings already up to date, skipping", "date", parsed[0].StandingsDate)
+	}
+}
+
+// toStoreEntries converts parsed standings into store entries, parsing the raw
+// yyyy_mm_dd label into a real date once (all rows share it).
+func toStoreEntries(parsed []sources.VRSStanding) ([]store.VRSEntry, error) {
+	date, err := time.Parse(vrsStandingsDateLayout, parsed[0].StandingsDate)
+	if err != nil {
+		return nil, fmt.Errorf("parse standings date %q: %w", parsed[0].StandingsDate, err)
+	}
+
+	entries := make([]store.VRSEntry, 0, len(parsed))
+	for _, p := range parsed {
+		entries = append(entries, store.VRSEntry{
+			Standing:      p.Standing,
+			Points:        p.Points,
+			TeamName:      p.TeamName,
+			Roster:        p.Roster,
+			StandingsDate: date,
+		})
+	}
+	return entries, nil
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"pickems-bot/app"
 	bot "pickems-bot/bot"
 	"pickems-bot/config"
+	"pickems-bot/ingest"
 	"pickems-bot/web"
 
 	"github.com/joho/godotenv"
@@ -60,6 +61,18 @@ func main() {
 		os.Exit(1)
 	}
 	defer apiInstance.Store.Close()
+
+	// Background ingestion jobs: keep the tournament catalog (/config picklist) and
+	// VRS rankings fresh, independent of the live-match poller. They run for the
+	// lifetime of the process on their own schedules; the tournament job shares the
+	// app's PandaScore rate limiter via app.Wait.
+	ingestCtx := context.Background()
+	if pandaKey := os.Getenv("PANDASCORE_API_KEY"); pandaKey != "" {
+		go ingest.NewTournamentSync(apiInstance, pandaKey, time.Hour, logger).Start(ingestCtx)
+	} else {
+		logger.Warn("PANDASCORE_API_KEY not set, tournament catalog sync disabled")
+	}
+	go ingest.NewVRSSync(apiInstance, time.Hour, logger).Start(ingestCtx)
 
 	var discordToken string
 	if cfg.Test {

--- a/sources/pandascore_tournaments.go
+++ b/sources/pandascore_tournaments.go
@@ -1,3 +1,5 @@
+//TODO: implement format detection to be used by tournament fetcher
+
 package sources
 
 import (
@@ -13,6 +15,7 @@ import (
 const (
 	pandaScoreUpcomingTournamentsURL = "https://api.pandascore.co/csgo/tournaments/upcoming?filter[tier]&page[size]=100"
 	pandaScoreRunningTournamentsURL  = "https://api.pandascore.co/csgo/tournaments/running?filter[tier]&page[size]=100"
+	pandaScoreBracketURLTemplate     = "https://api.pandascore.co/tournaments/%d/brackets?page[size]=100"
 )
 
 // PandaScoreTournament is a tournament (stage) as returned by the PandaScore
@@ -32,6 +35,53 @@ type PandaScoreTournament struct {
 		Name     string `json:"name"`
 		FullName string `json:"full_name"`
 	} `json:"serie"`
+}
+
+// BracketMatch is one match from the PandaScore brackets endpoint. Only the
+// fields needed for format detection and team counting are decoded.
+type BracketMatch struct {
+	ID              int               `json:"id"`
+	PreviousMatches []BracketEdge     `json:"previous_matches"`
+	Opponents       []BracketOpponent `json:"opponents"`
+}
+
+// BracketEdge links a match to a feeder match: Type ("winner" or "loser")
+// identifies which prior-match outcome advances into it. A "loser" edge means a
+// lower bracket exists, i.e. double-elimination.
+type BracketEdge struct {
+	FromMatchID int    `json:"match_id"`
+	Type        string `json:"type"` // "winner" or "loser"
+}
+
+// BracketOpponent wraps one side of a match. Opponent is nil for a TBD slot
+// (a not-yet-decided seed), so callers must nil-check before reading it.
+type BracketOpponent struct {
+	Opponent *BracketTeam `json:"opponent"`
+}
+
+// BracketTeam is the minimal team identity carried on a bracket match opponent.
+// acronym is frequently null in the API, so ID is the reliable identity key.
+type BracketTeam struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// CountTeams returns the number of distinct teams across a bracket's matches,
+// keyed on opponent ID. TBD/nil opponents are skipped. This is reliable for the
+// group-stage case that needs it: a round-robin has every pairing up front, and
+// a swiss's round 1 includes every team, so both surface the full field even
+// before play. Elimination brackets have TBD later rounds, but they are
+// classified by their edges and never reach the team-count check.
+func CountTeams(matches []BracketMatch) int {
+	seen := make(map[int]struct{})
+	for _, m := range matches {
+		for _, o := range m.Opponents {
+			if o.Opponent != nil && o.Opponent.ID != 0 {
+				seen[o.Opponent.ID] = struct{}{}
+			}
+		}
+	}
+	return len(seen)
 }
 
 // GetUpcomingPandaScoreTournaments fetches the upcoming tournaments for the catalog.
@@ -87,4 +137,39 @@ func (t PandaScoreTournament) DisplayName() string {
 	}
 
 	return t.League.Name
+}
+
+// GetPandaScoreBracket fetches the bracket (the match feeder graph) for a
+// PandaScore tournament, used to classify its format. Returns ErrUnrecoverable
+// on 401/403/404.
+func GetPandaScoreBracket(apiKey string, tournamentID int) ([]BracketMatch, error) {
+	url := fmt.Sprintf(pandaScoreBracketURLTemplate, tournamentID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Add("accept", "application/json")
+	req.Header.Add("authorization", "Bearer "+apiKey)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusUnauthorized ||
+		res.StatusCode == http.StatusForbidden ||
+		res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: status %d from %s", ErrUnrecoverable, res.StatusCode, url)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", res.StatusCode, url)
+	}
+
+	var bracket []BracketMatch
+	if err := json.NewDecoder(res.Body).Decode(&bracket); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return bracket, nil
 }

--- a/sources/pandascore_tournaments.go
+++ b/sources/pandascore_tournaments.go
@@ -1,0 +1,90 @@
+package sources
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// PandaScore tournament-listing endpoints. Both use page[size]=100 so the full
+// active set fits in one call: the catalog finished-diff treats any DB tournament
+// missing from the active set as finished, so a truncated page would wrongly mark
+// the overflow as finished.
+const (
+	pandaScoreUpcomingTournamentsURL = "https://api.pandascore.co/csgo/tournaments/upcoming?filter[tier]&page[size]=100"
+	pandaScoreRunningTournamentsURL  = "https://api.pandascore.co/csgo/tournaments/running?filter[tier]&page[size]=100"
+)
+
+// PandaScoreTournament is a tournament (stage) as returned by the PandaScore
+// tournaments endpoints. In PandaScore's model each stage of a series is its own
+// tournament; Round is the stage name (e.g. "Playoffs") and SerieID groups the
+// stages of one event.
+type PandaScoreTournament struct {
+	ID      int    `json:"id"`
+	Round   string `json:"name"`
+	SerieID int    `json:"serie_id"`
+
+	League struct {
+		Name string `json:"name"`
+	} `json:"league"`
+
+	Serie struct {
+		Name     string `json:"name"`
+		FullName string `json:"full_name"`
+	} `json:"serie"`
+}
+
+// GetUpcomingPandaScoreTournaments fetches the upcoming tournaments for the catalog.
+func GetUpcomingPandaScoreTournaments(apiKey string) ([]PandaScoreTournament, error) {
+	return getPandaScoreTournaments(apiKey, pandaScoreUpcomingTournamentsURL)
+}
+
+// GetRunningPandaScoreTournaments fetches the currently-running tournaments for the catalog.
+func GetRunningPandaScoreTournaments(apiKey string) ([]PandaScoreTournament, error) {
+	return getPandaScoreTournaments(apiKey, pandaScoreRunningTournamentsURL)
+}
+
+func getPandaScoreTournaments(apiKey, url string) ([]PandaScoreTournament, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Add("accept", "application/json")
+	req.Header.Add("authorization", "Bearer "+apiKey)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusUnauthorized ||
+		res.StatusCode == http.StatusForbidden ||
+		res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: status %d from %s", ErrUnrecoverable, res.StatusCode, url)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", res.StatusCode, url)
+	}
+
+	var tournaments []PandaScoreTournament
+	if err := json.NewDecoder(res.Body).Decode(&tournaments); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return tournaments, nil
+}
+
+// DisplayName builds the human-readable tournament name shown in the /config
+// picklist, preferring the serie name and falling back to the league name.
+func (t PandaScoreTournament) DisplayName() string {
+	if t.Serie.Name != "" {
+		return fmt.Sprintf("%s %s", t.League.Name, t.Serie.Name)
+	}
+
+	if t.Serie.FullName != "" {
+		return fmt.Sprintf("%s %s", t.League.Name, t.Serie.FullName)
+	}
+
+	return t.League.Name
+}

--- a/sources/vrs.go
+++ b/sources/vrs.go
@@ -1,0 +1,133 @@
+package sources
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// vrsStandingsContentsURL is the GitHub contents API listing for the current
+// year's VRS global-standings snapshots. Files are named with a yyyy_mm_dd
+// suffix, so the last entry alphabetically is always the most recent snapshot.
+// Note: the year is hard-coded and must be advanced each season.
+const vrsStandingsContentsURL = "https://api.github.com/repos/ValveSoftware/counter-strike_regional_standings/contents/live/2026"
+
+// VRSStanding is one team's row parsed from a VRS standings markdown snapshot.
+// StandingsDate is the raw yyyy_mm_dd label from the file header; callers parse
+// it into a real date before persisting.
+type VRSStanding struct {
+	Standing      int
+	Points        int
+	TeamName      string
+	Roster        []string
+	StandingsDate string
+}
+
+// FetchLatestVRSStandings resolves the most recent VRS standings snapshot on
+// GitHub and returns its raw markdown content.
+func FetchLatestVRSStandings() (string, error) {
+	url, err := latestVRSStandingsURL()
+	if err != nil {
+		return "", fmt.Errorf("resolve standings url: %w", err)
+	}
+	return fetchVRSStandingsFile(url)
+}
+
+// latestVRSStandingsURL returns the raw download URL for the newest standings file.
+func latestVRSStandingsURL() (string, error) {
+	resp, err := http.Get(vrsStandingsContentsURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: status %d from github contents api", ErrUnrecoverable, resp.StatusCode)
+	}
+
+	var contents []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&contents); err != nil {
+		return "", err
+	}
+	if len(contents) == 0 {
+		return "", fmt.Errorf("no standings files listed at %s", vrsStandingsContentsURL)
+	}
+
+	url, ok := contents[len(contents)-1]["download_url"].(string)
+	if !ok {
+		return "", fmt.Errorf("standings listing missing download_url")
+	}
+	return url, nil
+}
+
+// fetchVRSStandingsFile downloads the raw markdown content at the given URL.
+func fetchVRSStandingsFile(fileURL string) (string, error) {
+	resp, err := http.Get(fileURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// ParseVRSStandings parses a VRS standings markdown file into standings rows.
+// The header line ("### Standings as of 2026_05_04<br />") populates StandingsDate.
+// A data row looks like: | 1 | 2081 | Vitality | apEX, flameZ, mezii, ropz, ZywOo | [details](...) |
+func ParseVRSStandings(content string) []VRSStanding {
+	var standingsDate string
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if date, ok := strings.CutPrefix(line, "### Standings as of "); ok {
+			standingsDate = strings.TrimSpace(strings.TrimSuffix(date, "<br />"))
+			break
+		}
+	}
+
+	seen := make(map[string]bool)
+	var entries []VRSStanding
+
+	for line := range strings.SplitSeq(content, "\n") {
+		// data rows start with "| 1 |" etc — skip header, separator, empty lines
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+
+		cols := strings.Split(line, "|")
+		if len(cols) < 5 {
+			continue
+		}
+
+		standing, err := strconv.Atoi(strings.TrimSpace(cols[1]))
+		if err != nil {
+			continue // skips header and separator rows
+		}
+
+		teamName := strings.TrimSpace(cols[3])
+		if seen[teamName] {
+			continue // keep only first (best) occurrence
+		}
+		seen[teamName] = true
+
+		roster := strings.Split(strings.TrimSpace(cols[4]), ", ")
+		points, _ := strconv.Atoi(strings.TrimSpace(cols[2]))
+
+		entries = append(entries, VRSStanding{
+			Standing:      standing,
+			Points:        points,
+			TeamName:      teamName,
+			Roster:        roster,
+			StandingsDate: standingsDate,
+		})
+	}
+
+	return entries
+}

--- a/sources/vrs_test.go
+++ b/sources/vrs_test.go
@@ -1,0 +1,41 @@
+package sources
+
+import "testing"
+
+func TestParseVRSStandings(t *testing.T) {
+	content := `# Counter-Strike Regional Standings
+
+### Standings as of 2026_05_04<br />
+
+| Rank | Points | Team | Players | Details |
+| --- | --- | --- | --- | --- |
+| 1 | 2081 | Vitality | apEX, flameZ, mezii, ropz, ZywOo | [details](url) |
+| 2 | 1800 | FaZe | karrigan, rain, frozen, ropz, broky | [details](url) |
+| 2 | 1800 | FaZe | karrigan, rain, frozen, ropz, broky | [details](url) |
+`
+
+	got := ParseVRSStandings(content)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries (duplicate FaZe row dropped), got %d: %+v", len(got), got)
+	}
+
+	if got[0].StandingsDate != "2026_05_04" {
+		t.Errorf("standings date = %q, want %q", got[0].StandingsDate, "2026_05_04")
+	}
+
+	first := got[0]
+	if first.Standing != 1 || first.Points != 2081 || first.TeamName != "Vitality" {
+		t.Errorf("first entry = %+v, want standing 1 / points 2081 / Vitality", first)
+	}
+	if len(first.Roster) != 5 {
+		t.Errorf("Vitality roster size = %d, want 5 (%+v)", len(first.Roster), first.Roster)
+	}
+}
+
+func TestParseVRSStandings_NoDataRows(t *testing.T) {
+	got := ParseVRSStandings("### Standings as of 2026_05_04<br />\n\nno table here\n")
+	if len(got) != 0 {
+		t.Errorf("expected no entries, got %d", len(got))
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -23,6 +23,7 @@ type Interface interface {
 	ListRoundsForTournament(ctx context.Context, name string) ([]string, error)
 	GetTournamentByNameAndRound(ctx context.Context, name, round string) (Tournament, error)
 	GetTournament(ctx context.Context, id int) (Tournament, error)
+	SetTournamentFormat(ctx context.Context, id int, format string) error
 	SyncTournaments(ctx context.Context, active []TournamentCatalogEntry) error
 
 	// Guild config — new in v4, used by /config (#67)

--- a/store/store.go
+++ b/store/store.go
@@ -23,6 +23,7 @@ type Interface interface {
 	ListRoundsForTournament(ctx context.Context, name string) ([]string, error)
 	GetTournamentByNameAndRound(ctx context.Context, name, round string) (Tournament, error)
 	GetTournament(ctx context.Context, id int) (Tournament, error)
+	SyncTournaments(ctx context.Context, active []TournamentCatalogEntry) error
 
 	// Guild config — new in v4, used by /config (#67)
 	EnsureGuild(ctx context.Context, guildID string) error
@@ -53,6 +54,7 @@ type Interface interface {
 
 	// VRS
 	ListVRSRankings(ctx context.Context) ([]VRSEntry, error)
+	SyncStandings(ctx context.Context, entries []VRSEntry) (bool, error)
 }
 
 // PostgresStore represents the database connection and configuration

--- a/store/tournament.go
+++ b/store/tournament.go
@@ -29,6 +29,71 @@ func (s *PostgresStore) EnsureTournament(ctx context.Context, externalID, source
 	return id, nil
 }
 
+// TournamentCatalogEntry is one resolved PandaScore tournament (stage) to upsert
+// into the catalog. The caller (the ingest job) has already turned the raw
+// PandaScore payload into these fields, so the store stays free of source types.
+type TournamentCatalogEntry struct {
+	ExternalID string
+	Name       string
+	Round      string
+	SeriesID   string
+}
+
+// SyncTournaments upserts the active (upcoming + running) PandaScore tournaments
+// as not-finished, then marks any pandascore row that has dropped out of the
+// active set as finished. Both steps run in one transaction.
+//
+// The finished-sweep only runs when active is non-empty: an empty set almost
+// always means a bad API response rather than "no tournaments exist", and
+// sweeping on it would wrongly mark every row finished. Callers must ensure both
+// PandaScore fetches succeeded before combining them into active; a failed fetch
+// must not reach here as a short active set. An empty active set is rejected.
+//
+// Unlike EnsureTournament (the startup path, which preserves round on conflict),
+// this owns round/series_id for pandascore catalog rows and overwrites them, and
+// resets is_finished to false: anything in the active set is by definition live,
+// so a previously-swept tournament that reappears is reactivated.
+func (s *PostgresStore) SyncTournaments(ctx context.Context, active []TournamentCatalogEntry) error {
+	if len(active) == 0 {
+		return fmt.Errorf("SyncTournaments: empty active set, refusing to run finished-sweep")
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("SyncTournaments: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	activeIDs := make([]string, 0, len(active))
+	for _, t := range active {
+		activeIDs = append(activeIDs, t.ExternalID)
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO tournaments (external_id, source, name, round, series_id, is_finished)
+			VALUES ($1, 'pandascore', $2, $3, $4, false)
+			ON CONFLICT (source, external_id) DO UPDATE SET
+				name        = EXCLUDED.name,
+				round       = EXCLUDED.round,
+				series_id   = EXCLUDED.series_id,
+				is_finished = false
+		`, t.ExternalID, t.Name, t.Round, t.SeriesID); err != nil {
+			return fmt.Errorf("SyncTournaments: upsert %q: %w", t.Name, err)
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE tournaments
+		   SET is_finished = true
+		 WHERE source = 'pandascore'
+		   AND is_finished = false
+		   AND external_id <> ALL($1)
+	`, activeIDs); err != nil {
+		return fmt.Errorf("SyncTournaments: finished-sweep: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
 // Tournament is a lightweight view of a tournament row, used to populate the
 // /config set-tournament picklist. Source-agnostic: the caller stores the ID.
 // Round is the stage label (e.g. "Qualifier", "Playoffs") that distinguishes

--- a/store/tournament.go
+++ b/store/tournament.go
@@ -100,9 +100,14 @@ func (s *PostgresStore) SyncTournaments(ctx context.Context, active []Tournament
 // rows sharing a name within a series; it may be empty for sources that don't
 // split a tournament into stages.
 type Tournament struct {
-	ID    int
-	Name  string
-	Round string
+	ID         int
+	Source     string
+	ExternalID string
+	Round      string
+	Name       string
+	SeriesID   string
+	Format     *string
+	isFinished bool
 }
 
 // ListTournamentNames returns the distinct tournament names for the /config
@@ -166,10 +171,10 @@ func (s *PostgresStore) ListRoundsForTournament(ctx context.Context, name string
 func (s *PostgresStore) GetTournamentByNameAndRound(ctx context.Context, name, round string) (Tournament, error) {
 	var t Tournament
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, name, COALESCE(round, '') FROM tournaments
+		tournamentSelect+`
 		 WHERE name = $1 AND COALESCE(round, '') = $2
 		 ORDER BY id LIMIT 1`, name, round,
-	).Scan(&t.ID, &t.Name, &t.Round)
+	).Scan(&t.ID, &t.Source, &t.ExternalID, &t.Round, &t.Name, &t.SeriesID, &t.Format, &t.isFinished)
 	if err != nil {
 		return Tournament{}, fmt.Errorf("GetTournamentByNameAndRound: %w", err)
 	}
@@ -178,14 +183,31 @@ func (s *PostgresStore) GetTournamentByNameAndRound(ctx context.Context, name, r
 
 // GetTournament returns a single tournament by its internal DB id. Used by
 // /config set-round to recover the currently-configured tournament's name so
-// the round autocomplete can be scoped to that tournament.
+// the round autocomplete can be scoped to that tournament, and by the format
+// detection hook to read source/external_id/format.
 func (s *PostgresStore) GetTournament(ctx context.Context, id int) (Tournament, error) {
 	var t Tournament
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, name, COALESCE(round, '') FROM tournaments WHERE id = $1`, id,
-	).Scan(&t.ID, &t.Name, &t.Round)
+		tournamentSelect+` WHERE id = $1`, id,
+	).Scan(&t.ID, &t.Source, &t.ExternalID, &t.Round, &t.Name, &t.SeriesID, &t.Format, &t.isFinished)
 	if err != nil {
 		return Tournament{}, fmt.Errorf("GetTournament: %w", err)
 	}
 	return t, nil
+}
+
+// tournamentSelect is the shared column list for reading a full Tournament row.
+// Nullable text columns are COALESCEd to ""; format stays nullable (*string) so
+// callers can tell "not yet detected" (nil) from a real value.
+const tournamentSelect = `SELECT id, source, external_id, COALESCE(round, ''), name, COALESCE(series_id, ''), format, is_finished FROM tournaments`
+
+// SetTournamentFormat records the detected format for a tournament. The caller
+// decides when to run detection (e.g. only when format is currently unset); this
+// is a plain setter and will overwrite any existing value.
+func (s *PostgresStore) SetTournamentFormat(ctx context.Context, id int, format string) error {
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE tournaments SET format = $1 WHERE id = $2`, format, id); err != nil {
+		return fmt.Errorf("SetTournamentFormat: %w", err)
+	}
+	return nil
 }

--- a/store/tournament_test.go
+++ b/store/tournament_test.go
@@ -101,3 +101,78 @@ func TestGetTournament_ByID(t *testing.T) {
 	assert.Equal(t, "Alpha Major", got.Name)
 	assert.Equal(t, "Qualifier", got.Round)
 }
+
+func TestSyncTournaments_UpsertsActiveSet(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	require.NoError(t, s.SyncTournaments(ctx, []TournamentCatalogEntry{
+		{ExternalID: "21474", Name: "BLAST Bounty Summer 2026", Round: "Qualifier", SeriesID: "10801"},
+		{ExternalID: "21475", Name: "BLAST Bounty Summer 2026", Round: "Playoffs", SeriesID: "10801"},
+	}))
+
+	names, err := s.ListTournamentNames(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"BLAST Bounty Summer 2026"}, names) // collapsed to one name
+
+	rounds, err := s.ListRoundsForTournament(ctx, "BLAST Bounty Summer 2026")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"Qualifier", "Playoffs"}, rounds)
+}
+
+func TestSyncTournaments_MarksDroppedAsFinished(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	require.NoError(t, s.SyncTournaments(ctx, []TournamentCatalogEntry{
+		{ExternalID: "1", Name: "Event A", Round: "Playoffs", SeriesID: "100"},
+		{ExternalID: "2", Name: "Event B", Round: "Playoffs", SeriesID: "200"},
+	}))
+
+	// Event B drops out of the active set -> swept to finished; A stays active.
+	require.NoError(t, s.SyncTournaments(ctx, []TournamentCatalogEntry{
+		{ExternalID: "1", Name: "Event A", Round: "Playoffs", SeriesID: "100"},
+	}))
+
+	assert.False(t, tournamentFinished(t, ctx, "1"), "Event A still active")
+	assert.True(t, tournamentFinished(t, ctx, "2"), "Event B dropped -> finished")
+}
+
+func TestSyncTournaments_ReactivatesReturningTournament(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	require.NoError(t, s.SyncTournaments(ctx, []TournamentCatalogEntry{
+		{ExternalID: "1", Name: "Event A", Round: "Playoffs", SeriesID: "100"},
+		{ExternalID: "2", Name: "Event B", Round: "Playoffs", SeriesID: "200"},
+	}))
+	require.NoError(t, s.SyncTournaments(ctx, []TournamentCatalogEntry{
+		{ExternalID: "1", Name: "Event A", Round: "Playoffs", SeriesID: "100"},
+	})) // B -> finished
+	require.NoError(t, s.SyncTournaments(ctx, []TournamentCatalogEntry{
+		{ExternalID: "1", Name: "Event A", Round: "Playoffs", SeriesID: "100"},
+		{ExternalID: "2", Name: "Event B", Round: "Playoffs", SeriesID: "200"},
+	})) // B reappears in the active set
+
+	assert.False(t, tournamentFinished(t, ctx, "2"), "Event B reappeared -> reactivated")
+}
+
+func TestSyncTournaments_EmptyActiveError(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	assert.Error(t, s.SyncTournaments(ctx, nil))
+}
+
+func tournamentFinished(t *testing.T, ctx context.Context, externalID string) bool {
+	t.Helper()
+	var finished bool
+	err := testPool.QueryRow(ctx,
+		`SELECT is_finished FROM tournaments WHERE source='pandascore' AND external_id=$1`, externalID).Scan(&finished)
+	require.NoError(t, err)
+	return finished
+}

--- a/store/vrs.go
+++ b/store/vrs.go
@@ -47,3 +47,89 @@ func (s *PostgresStore) ListVRSRankings(ctx context.Context) ([]VRSEntry, error)
 	}
 	return results, nil
 }
+
+// SyncStandings replaces the stored VRS standings when the fetched snapshot is
+// newer than what's stored. Returns true if a sync was performed, false if the
+// DB already holds this snapshot's date. All entries come from one snapshot and
+// share a StandingsDate; entries[0] supplies it. SyncedAt is stamped here.
+//
+// The clear-and-reinsert runs in a single transaction so the rankings are never
+// observably empty (an old row's roster is preserved until the new set commits).
+func (s *PostgresStore) SyncStandings(ctx context.Context, entries []VRSEntry) (bool, error) {
+	if len(entries) == 0 {
+		return false, fmt.Errorf("SyncStandings: no entries to sync")
+	}
+	fetchedDate := entries[0].StandingsDate
+
+	needed, err := s.standingsSyncNeeded(ctx, fetchedDate)
+	if err != nil {
+		return false, err
+	}
+	if !needed {
+		return false, nil
+	}
+
+	now := time.Now()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("SyncStandings: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Clear old rankings; teams are preserved since team identities have value
+	// beyond VRS data.
+	if _, err := tx.Exec(ctx, `DELETE FROM team_rankings`); err != nil {
+		return false, fmt.Errorf("SyncStandings: clear rankings: %w", err)
+	}
+
+	for _, e := range entries {
+		var teamID int
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO teams (canonical_name, source, external_id)
+			VALUES ($1, 'vrs', $1)
+			ON CONFLICT (source, external_id) DO UPDATE SET canonical_name = EXCLUDED.canonical_name
+			RETURNING id
+		`, e.TeamName).Scan(&teamID); err != nil {
+			return false, fmt.Errorf("SyncStandings: upsert team %q: %w", e.TeamName, err)
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO team_rankings (team_id, standing, points, roster, standings_date, synced_at)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (team_id, standings_date) DO UPDATE SET
+				standing  = EXCLUDED.standing,
+				points    = EXCLUDED.points,
+				roster    = EXCLUDED.roster,
+				synced_at = EXCLUDED.synced_at
+		`, teamID, e.Standing, e.Points, e.Roster, fetchedDate, now); err != nil {
+			return false, fmt.Errorf("SyncStandings: insert ranking for %q: %w", e.TeamName, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("SyncStandings: commit: %w", err)
+	}
+	return true, nil
+}
+
+// standingsSyncNeeded reports whether the fetched snapshot should replace what's
+// stored: true when the table is empty, holds an inconsistent set of dates, or
+// holds a different date than fetchedDate (compared at day granularity).
+func (s *PostgresStore) standingsSyncNeeded(ctx context.Context, fetchedDate time.Time) (bool, error) {
+	var groupCount int
+	var latestDate *time.Time
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT standings_date), MAX(standings_date) FROM team_rankings
+	`).Scan(&groupCount, &latestDate); err != nil {
+		return false, fmt.Errorf("standingsSyncNeeded: %w", err)
+	}
+
+	switch groupCount {
+	case 0:
+		return true, nil
+	case 1:
+		return !latestDate.Truncate(24 * time.Hour).Equal(fetchedDate.Truncate(24 * time.Hour)), nil
+	default:
+		return true, nil // inconsistent state, resync
+	}
+}

--- a/store/vrs_test.go
+++ b/store/vrs_test.go
@@ -93,3 +93,75 @@ func TestListVRSRankings_OrderedByStanding(t *testing.T) {
 	assert.Equal(t, 3, entries[2].Standing)
 	assert.Equal(t, "Vitality", entries[2].TeamName)
 }
+
+func TestSyncStandings_InsertsAndReports(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	date := time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC)
+	synced, err := s.SyncStandings(ctx, []VRSEntry{
+		{Standing: 1, Points: 2000, TeamName: "Vitality", Roster: []string{"ZywOo", "apEX"}, StandingsDate: date},
+		{Standing: 2, Points: 1800, TeamName: "FaZe", Roster: []string{"karrigan"}, StandingsDate: date},
+	})
+	require.NoError(t, err)
+	assert.True(t, synced)
+
+	got, err := s.ListVRSRankings(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "Vitality", got[0].TeamName)
+	assert.Equal(t, 1, got[0].Standing)
+}
+
+func TestSyncStandings_SkipsWhenDateUnchanged(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	date := time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC)
+	entries := []VRSEntry{{Standing: 1, Points: 2000, TeamName: "Vitality", Roster: []string{"ZywOo"}, StandingsDate: date}}
+
+	synced, err := s.SyncStandings(ctx, entries)
+	require.NoError(t, err)
+	require.True(t, synced)
+
+	// Same snapshot date again is a no-op.
+	synced, err = s.SyncStandings(ctx, entries)
+	require.NoError(t, err)
+	assert.False(t, synced)
+}
+
+func TestSyncStandings_ReplacesOnNewerDate(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	oldDate := time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC)
+	_, err := s.SyncStandings(ctx, []VRSEntry{
+		{Standing: 1, Points: 2000, TeamName: "Vitality", Roster: []string{"ZywOo"}, StandingsDate: oldDate},
+		{Standing: 2, Points: 1800, TeamName: "FaZe", Roster: []string{"karrigan"}, StandingsDate: oldDate},
+	})
+	require.NoError(t, err)
+
+	newDate := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	synced, err := s.SyncStandings(ctx, []VRSEntry{
+		{Standing: 1, Points: 2100, TeamName: "Spirit", Roster: []string{"donk"}, StandingsDate: newDate},
+	})
+	require.NoError(t, err)
+	require.True(t, synced)
+
+	got, err := s.ListVRSRankings(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1) // old rankings cleared, teams preserved
+	assert.Equal(t, "Spirit", got[0].TeamName)
+}
+
+func TestSyncStandings_EmptyEntriesError(t *testing.T) {
+	cleanDB(t)
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	_, err := s.SyncStandings(ctx, nil)
+	assert.Error(t, err)
+}

--- a/tournament/bracket_fixture_test.go
+++ b/tournament/bracket_fixture_test.go
@@ -1,0 +1,40 @@
+/* bracket_fixture_test.go
+ * Detector tests backed by real /brackets payloads captured from PandaScore,
+ * to guard against the actual API shape (not just synthetic edge lists).
+ * Fixtures live in testdata/.
+ */
+
+package tournament
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pickems-bot/sources"
+)
+
+func loadBracketFixture(t *testing.T, name string) []sources.BracketMatch {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	require.NoError(t, err)
+	var matches []sources.BracketMatch
+	require.NoError(t, json.Unmarshal(data, &matches))
+	return matches
+}
+
+// A real 5-team single round-robin: edge-less (like swiss) but matchCount ==
+// n*(n-1)/2, so it must classify as Other, not Swiss. Also exercises the full
+// path: decode -> sources.CountTeams -> DetectKindFromBracket.
+func TestDetectKindFromBracket_RealRoundRobin(t *testing.T) {
+	matches := loadBracketFixture(t, "roundrobin_brackets.json")
+
+	assert.Len(t, matches, 10, "single round-robin of 5 teams is 5*4/2 = 10 matches")
+
+	n := sources.CountTeams(matches)
+	assert.Equal(t, 5, n, "distinct teams derived from opponent IDs")
+
+	assert.Equal(t, Other, DetectKindFromBracket(matches, n))
+}

--- a/tournament/format.go
+++ b/tournament/format.go
@@ -26,6 +26,7 @@ const (
 	SingleElim Kind = "single-elimination"
 	// DoubleElim is not fully supported yet. Only exists for upcoming only mode
 	DoubleElim Kind = "double-elimination"
+	Other      Kind = "other"
 )
 
 // MatchResult is the unified interface implemented by every per-format result
@@ -187,4 +188,43 @@ func DetectKindFromMatchNodes(nodes []sources.MatchNode) (Kind, error) {
 	default:
 		return "", fmt.Errorf("could not detect tournament format from match node sections")
 	}
+}
+
+// DetectKindFromBracket infers the tournament format from a slice of BracketMatch
+// returned by the PandaScore API
+// Priority: DoubleElim (upper + lower edges) > SingleElim (upper edges only) > Swiss (no edges) > Other (unknown or empty).
+func DetectKindFromBracket(matches []sources.BracketMatch, teamCount int) Kind {
+	if len(matches) == 0 {
+		return Other
+	}
+	var hasWinnerEdge, hasLoserEdge bool
+	for _, m := range matches {
+		for _, e := range m.PreviousMatches {
+			switch strings.ToLower(e.Type) {
+			case "winner":
+				hasWinnerEdge = true
+			case "loser":
+				hasLoserEdge = true
+			}
+		}
+	}
+	switch {
+	case hasLoserEdge:
+		return DoubleElim // a loser bracket only exists in double-elim
+	case hasWinnerEdge:
+		return SingleElim // a single winner-fed tree
+	default:
+		if isRoundRobin(len(matches), teamCount) {
+			return Other // round-robin is not a supported format, but we can detect it
+		}
+		return Swiss // no feeder edges anywhere -> standings-based
+	}
+}
+
+// isRoundRobin returns true if the given number of matches and teams corresponds
+func isRoundRobin(numMatches, teamCount int) bool {
+	if teamCount > 1 && numMatches == teamCount*(teamCount-1)/2 {
+		return true
+	}
+	return false
 }

--- a/tournament/format_test.go
+++ b/tournament/format_test.go
@@ -155,3 +155,101 @@ func TestFilterNodesByKind_DoubleElimPassesThrough(t *testing.T) {
 }
 
 // endregion
+
+// region DetectKindFromBracket
+
+// bm builds a BracketMatch whose previous_matches carry the given edge types.
+// Called with no arguments it is an entry-point match (empty previous_matches),
+// exactly how PandaScore represents an upper-round-1 / quarterfinal match.
+func bm(edgeTypes ...string) sources.BracketMatch {
+	var m sources.BracketMatch
+	for i, typ := range edgeTypes {
+		m.PreviousMatches = append(m.PreviousMatches, sources.BracketEdge{FromMatchID: i + 1, Type: typ})
+	}
+	return m
+}
+
+// edgelessBracket returns n entry-point matches (no feeder edges), the shape a
+// group stage (swiss / round-robin) has - pairings come from standings, not
+// from prior match outcomes.
+func edgelessBracket(n int) []sources.BracketMatch {
+	return make([]sources.BracketMatch, n)
+}
+
+func TestDetectKindFromBracket_DoubleElim(t *testing.T) {
+	// Entry matches with no edges, a winner-fed upper match, at least one
+	// loser-fed lower-bracket match, and a winner-fed grand final.
+	matches := []sources.BracketMatch{
+		bm(), bm(),
+		bm("winner", "winner"),
+		bm("loser", "winner"),
+		bm("winner", "winner"),
+	}
+	assert.Equal(t, DoubleElim, DetectKindFromBracket(matches, 8))
+}
+
+func TestDetectKindFromBracket_SingleElim(t *testing.T) {
+	// 8-team single elim: 4 entry-point quarterfinals, 2 semis, 1 final; winner edges only.
+	matches := []sources.BracketMatch{
+		bm(), bm(), bm(), bm(),
+		bm("winner", "winner"), bm("winner", "winner"),
+		bm("winner", "winner"),
+	}
+	assert.Equal(t, SingleElim, DetectKindFromBracket(matches, 8))
+}
+
+func TestDetectKindFromBracket_Swiss(t *testing.T) {
+	// 16-team swiss, 33 matches, no feeder edges. 33 != 16*15/2 (=120), so not round-robin.
+	assert.Equal(t, Swiss, DetectKindFromBracket(edgelessBracket(33), 16))
+}
+
+func TestDetectKindFromBracket_RoundRobinReportedAsOther(t *testing.T) {
+	// 4 teams, 6 matches (== 4*3/2), no edges -> round-robin -> Other (no scorer).
+	assert.Equal(t, Other, DetectKindFromBracket(edgelessBracket(6), 4))
+}
+
+func TestDetectKindFromBracket_EmptyIsOther(t *testing.T) {
+	assert.Equal(t, Other, DetectKindFromBracket(nil, 8))
+	assert.Equal(t, Other, DetectKindFromBracket([]sources.BracketMatch{}, 8))
+}
+
+func TestDetectKindFromBracket_LoserEdgeWinsOverWinnerEdges(t *testing.T) {
+	// A single loser edge means a lower bracket exists -> double-elim, even amid
+	// many winner edges. Guards the priority ordering.
+	matches := []sources.BracketMatch{
+		bm("winner", "winner"),
+		bm("winner", "winner"),
+		bm("loser", "winner"),
+	}
+	assert.Equal(t, DoubleElim, DetectKindFromBracket(matches, 8))
+}
+
+func TestDetectKindFromBracket_EntryPointMatchesDoNotForceGroup(t *testing.T) {
+	// Edge-less entry matches appearing before any edged match must not short-circuit
+	// to a group classification: the scan is over the whole set, order-independent.
+	matches := []sources.BracketMatch{
+		bm(), bm(), bm(),
+		bm("winner", "winner"),
+	}
+	assert.Equal(t, SingleElim, DetectKindFromBracket(matches, 8))
+}
+
+func TestDetectKindFromBracket_EdgeTypeCaseInsensitive(t *testing.T) {
+	assert.Equal(t, DoubleElim, DetectKindFromBracket([]sources.BracketMatch{bm("LOSER")}, 8))
+	assert.Equal(t, SingleElim, DetectKindFromBracket([]sources.BracketMatch{bm("Winner")}, 8))
+}
+
+// endregion
+
+// region isRoundRobin
+
+func TestIsRoundRobin(t *testing.T) {
+	assert.True(t, isRoundRobin(6, 4))    // 4 teams -> 6 matches
+	assert.True(t, isRoundRobin(10, 5))   // 5 teams -> 10 matches
+	assert.False(t, isRoundRobin(33, 16)) // swiss, far short of the full 120
+	assert.False(t, isRoundRobin(5, 4))   // wrong count for 4 teams
+	assert.False(t, isRoundRobin(0, 1))   // single team guarded out
+	assert.False(t, isRoundRobin(0, 0))   // no teams
+}
+
+// endregion

--- a/tournament/testdata/roundrobin_brackets.json
+++ b/tournament/testdata/roundrobin_brackets.json
@@ -1,0 +1,1362 @@
+[
+    {
+        "id": 1616711,
+        "name": "GamersLab Esports vs maybe",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 138899
+            },
+            {
+                "score": 0,
+                "team_id": 139045
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-06T14:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "gamerslab-esports-vs-maybe-2026-08-06",
+        "games": [
+            {
+                "complete": false,
+                "id": 225056,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616711,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225057,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616711,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225058,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616711,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-06T14:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139045,
+                    "name": "GamersLab Esports",
+                    "location": "CZ",
+                    "slug": "gamerslab-esports",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 138899,
+                    "name": "maybe",
+                    "location": "UA",
+                    "slug": "maybe-cs-go",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": null,
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/138899/maybe__ukrainian_team__allmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/138899/maybe__ukrainian_team__allmode.png"
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-06T14:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616710,
+        "name": "NAVI.J vs JAM",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 139046
+            },
+            {
+                "score": 0,
+                "team_id": 126491
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-06T14:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "navi-junior-vs-jam-2026-08-06",
+        "games": [
+            {
+                "complete": false,
+                "id": 225053,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616710,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225054,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616710,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225055,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616710,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-06T14:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 126491,
+                    "name": "NAVI Junior",
+                    "location": "UA",
+                    "slug": "natus-vincere-junior",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": "NAVI.J",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/126491/630px_na_vi_jr.png",
+                    "dark_mode_image_url": null
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139046,
+                    "name": "JAM",
+                    "location": "UA",
+                    "slug": "jam",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-06T14:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616709,
+        "name": "maybe vs JAM",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 139046
+            },
+            {
+                "score": 0,
+                "team_id": 138899
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-06T11:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "maybe-vs-jam-2026-08-06",
+        "games": [
+            {
+                "complete": false,
+                "id": 225050,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616709,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225051,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616709,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225052,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616709,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-06T11:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 138899,
+                    "name": "maybe",
+                    "location": "UA",
+                    "slug": "maybe-cs-go",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": null,
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/138899/maybe__ukrainian_team__allmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/138899/maybe__ukrainian_team__allmode.png"
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139046,
+                    "name": "JAM",
+                    "location": "UA",
+                    "slug": "jam",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-06T11:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616708,
+        "name": "ESB vs NAVI.J",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 126491
+            },
+            {
+                "score": 0,
+                "team_id": 127497
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-06T11:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "esuba-vs-navi-junior-2026-08-06",
+        "games": [
+            {
+                "complete": false,
+                "id": 225047,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616708,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225048,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616708,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225049,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616708,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-06T11:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 127497,
+                    "name": "eSuba",
+                    "location": "CZ",
+                    "slug": "esuba-cs-go",
+                    "modified_at": "2026-08-02T06:58:59Z",
+                    "acronym": "ESB",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/127497/e_suba_2021_lightmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/127497/630px_e_suba_2021_darkmode.png"
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 126491,
+                    "name": "NAVI Junior",
+                    "location": "UA",
+                    "slug": "natus-vincere-junior",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": "NAVI.J",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/126491/630px_na_vi_jr.png",
+                    "dark_mode_image_url": null
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-06T11:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616707,
+        "name": "GamersLab Esports vs JAM",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 139046
+            },
+            {
+                "score": 0,
+                "team_id": 139045
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-05T17:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "gamerslab-esports-vs-jam-2026-08-05",
+        "games": [
+            {
+                "complete": false,
+                "id": 225044,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616707,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225045,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616707,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225046,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616707,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-05T17:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139045,
+                    "name": "GamersLab Esports",
+                    "location": "CZ",
+                    "slug": "gamerslab-esports",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139046,
+                    "name": "JAM",
+                    "location": "UA",
+                    "slug": "jam",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-05T17:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616706,
+        "name": "maybe vs ESB",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 127497
+            },
+            {
+                "score": 0,
+                "team_id": 138899
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-05T17:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "maybe-vs-esuba-2026-08-05",
+        "games": [
+            {
+                "complete": false,
+                "id": 225041,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616706,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225042,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616706,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225043,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616706,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-05T17:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 138899,
+                    "name": "maybe",
+                    "location": "UA",
+                    "slug": "maybe-cs-go",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": null,
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/138899/maybe__ukrainian_team__allmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/138899/maybe__ukrainian_team__allmode.png"
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 127497,
+                    "name": "eSuba",
+                    "location": "CZ",
+                    "slug": "esuba-cs-go",
+                    "modified_at": "2026-08-02T06:58:59Z",
+                    "acronym": "ESB",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/127497/e_suba_2021_lightmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/127497/630px_e_suba_2021_darkmode.png"
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-05T17:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616705,
+        "name": "JAM vs ESB",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 127497
+            },
+            {
+                "score": 0,
+                "team_id": 139046
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-05T14:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "jam-vs-esuba-2026-08-05",
+        "games": [
+            {
+                "complete": false,
+                "id": 225038,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616705,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225039,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616705,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225040,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616705,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-05T14:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139046,
+                    "name": "JAM",
+                    "location": "UA",
+                    "slug": "jam",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 127497,
+                    "name": "eSuba",
+                    "location": "CZ",
+                    "slug": "esuba-cs-go",
+                    "modified_at": "2026-08-02T06:58:59Z",
+                    "acronym": "ESB",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/127497/e_suba_2021_lightmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/127497/630px_e_suba_2021_darkmode.png"
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-05T14:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616704,
+        "name": "GamersLab Esports vs NAVI.J",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 126491
+            },
+            {
+                "score": 0,
+                "team_id": 139045
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-05T14:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "gamerslab-esports-vs-navi-junior-2026-08-05",
+        "games": [
+            {
+                "complete": false,
+                "id": 225035,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616704,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225036,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616704,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225037,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616704,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-05T14:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139045,
+                    "name": "GamersLab Esports",
+                    "location": "CZ",
+                    "slug": "gamerslab-esports",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 126491,
+                    "name": "NAVI Junior",
+                    "location": "UA",
+                    "slug": "natus-vincere-junior",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": "NAVI.J",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/126491/630px_na_vi_jr.png",
+                    "dark_mode_image_url": null
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-05T14:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616703,
+        "name": "NAVI.J vs maybe",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 138899
+            },
+            {
+                "score": 0,
+                "team_id": 126491
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-05T11:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "navi-junior-vs-maybe-2026-08-05",
+        "games": [
+            {
+                "complete": false,
+                "id": 225032,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616703,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225033,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616703,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225034,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616703,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-05T11:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 126491,
+                    "name": "NAVI Junior",
+                    "location": "UA",
+                    "slug": "natus-vincere-junior",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": "NAVI.J",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/126491/630px_na_vi_jr.png",
+                    "dark_mode_image_url": null
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 138899,
+                    "name": "maybe",
+                    "location": "UA",
+                    "slug": "maybe-cs-go",
+                    "modified_at": "2026-08-02T06:59:04Z",
+                    "acronym": null,
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/138899/maybe__ukrainian_team__allmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/138899/maybe__ukrainian_team__allmode.png"
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-05T11:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    },
+    {
+        "id": 1616702,
+        "name": "GamersLab Esports vs ESB",
+        "status": "not_started",
+        "results": [
+            {
+                "score": 0,
+                "team_id": 127497
+            },
+            {
+                "score": 0,
+                "team_id": 139045
+            }
+        ],
+        "live": {
+            "supported": false,
+            "url": null,
+            "opens_at": null
+        },
+        "begin_at": "2026-08-05T11:00:00Z",
+        "detailed_stats": false,
+        "end_at": null,
+        "forfeit": false,
+        "winner_id": null,
+        "winner_type": "Team",
+        "slug": "gamerslab-esports-vs-esuba-2026-08-05",
+        "games": [
+            {
+                "complete": false,
+                "id": 225029,
+                "position": 1,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616702,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225030,
+                "position": 2,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616702,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            },
+            {
+                "complete": false,
+                "id": 225031,
+                "position": 3,
+                "status": "not_started",
+                "length": null,
+                "finished": false,
+                "begin_at": null,
+                "detailed_stats": false,
+                "end_at": null,
+                "forfeit": false,
+                "match_id": 1616702,
+                "winner_type": "Team",
+                "winner": {
+                    "id": null,
+                    "type": "Team"
+                }
+            }
+        ],
+        "draw": false,
+        "tournament_id": 21606,
+        "modified_at": "2026-08-02T07:14:46Z",
+        "match_type": "best_of",
+        "number_of_games": 3,
+        "scheduled_at": "2026-08-05T11:00:00Z",
+        "opponents": [
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 139045,
+                    "name": "GamersLab Esports",
+                    "location": "CZ",
+                    "slug": "gamerslab-esports",
+                    "modified_at": "2026-08-02T06:59:05Z",
+                    "acronym": null,
+                    "image_url": null,
+                    "dark_mode_image_url": null
+                }
+            },
+            {
+                "type": "Team",
+                "opponent": {
+                    "id": 127497,
+                    "name": "eSuba",
+                    "location": "CZ",
+                    "slug": "esuba-cs-go",
+                    "modified_at": "2026-08-02T06:58:59Z",
+                    "acronym": "ESB",
+                    "image_url": "https://cdn-api.pandascore.co/images/team/image/127497/e_suba_2021_lightmode.png",
+                    "dark_mode_image_url": "https://cdn-api.pandascore.co/dark_images/team/dark_image/127497/630px_e_suba_2021_darkmode.png"
+                }
+            }
+        ],
+        "previous_matches": [],
+        "original_scheduled_at": "2026-08-05T11:00:00Z",
+        "game_advantage": null,
+        "streams_list": [
+            {
+                "main": false,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzoneup",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzoneup"
+            },
+            {
+                "main": true,
+                "language": "cs",
+                "embed_url": "https://player.twitch.tv/?channel=playzonecz",
+                "official": true,
+                "raw_url": "https://www.twitch.tv/playzonecz"
+            }
+        ]
+    }
+]

--- a/tournament/unsupported.go
+++ b/tournament/unsupported.go
@@ -1,0 +1,55 @@
+package tournament
+
+import (
+	"errors"
+
+	"pickems-bot/models"
+	"pickems-bot/sources"
+)
+
+// ErrPredictionsUnsupported is returned by every prediction/scoring method of a
+// format that the bot can catalog and show raw match data for, but cannot run
+// pick'ems on (double-elimination, or an unrecognised bracket classified as
+// "other"). Callers should surface a user-facing "predictions not supported"
+// message rather than treat it as an internal failure.
+var ErrPredictionsUnsupported = errors.New("tournament format does not support predictions")
+
+// unsupportedFormat is a null-object Format registered for the kinds we detect
+// but can't run predictions for. Registering it (instead of leaving Get to error)
+// is deliberate: non-prediction features (schedule, raw results, future
+// read-only commands) resolve the format cleanly, while every prediction/scoring
+// entry point returns ErrPredictionsUnsupported and does no work. Add a real
+// implementation later to promote a kind out of "unsupported".
+type unsupportedFormat struct{ kind Kind }
+
+var _ Format = unsupportedFormat{}
+
+func init() {
+	register(unsupportedFormat{kind: DoubleElim})
+	register(unsupportedFormat{kind: Other})
+}
+
+func (f unsupportedFormat) Name() Kind { return f.kind }
+
+// RequiredPredictions is 0: there are no predictions to make for this format.
+func (unsupportedFormat) RequiredPredictions(int) int { return 0 }
+
+func (unsupportedFormat) GeneratePrediction(models.User, string, []string) (models.Prediction, error) {
+	return models.Prediction{}, ErrPredictionsUnsupported
+}
+
+func (unsupportedFormat) CalculateScore(models.Prediction, MatchResult) (ScoreReport, error) {
+	return nil, ErrPredictionsUnsupported
+}
+
+func (unsupportedFormat) PredictionFields(models.Prediction) ([]models.PredictionField, error) {
+	return nil, ErrPredictionsUnsupported
+}
+
+func (unsupportedFormat) DecodeBSON([]byte) (MatchResult, error) {
+	return nil, ErrPredictionsUnsupported
+}
+
+func (unsupportedFormat) BuildFromMatchNodes([]sources.MatchNode, string) (MatchResult, error) {
+	return nil, ErrPredictionsUnsupported
+}

--- a/tournament/unsupported_test.go
+++ b/tournament/unsupported_test.go
@@ -1,0 +1,40 @@
+package tournament
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pickems-bot/models"
+)
+
+func TestUnsupportedFormat_ResolvesForUnscoreableKinds(t *testing.T) {
+	// Get must succeed for these kinds so non-prediction paths resolve the format
+	// cleanly instead of erroring on an unregistered kind.
+	for _, k := range []Kind{Other, DoubleElim} {
+		f, err := Get(k)
+		require.NoError(t, err, "kind %q should resolve to the unsupported format", k)
+		assert.Equal(t, k, f.Name())
+	}
+}
+
+func TestUnsupportedFormat_PredictionMethodsRefuse(t *testing.T) {
+	f := MustGet(Other)
+
+	assert.Equal(t, 0, f.RequiredPredictions(16))
+
+	_, err := f.GeneratePrediction(models.User{}, "Playoffs", []string{"A"})
+	assert.ErrorIs(t, err, ErrPredictionsUnsupported)
+
+	_, err = f.CalculateScore(models.Prediction{}, nil)
+	assert.ErrorIs(t, err, ErrPredictionsUnsupported)
+
+	_, err = f.PredictionFields(models.Prediction{})
+	assert.ErrorIs(t, err, ErrPredictionsUnsupported)
+
+	_, err = f.BuildFromMatchNodes(nil, "Playoffs")
+	assert.ErrorIs(t, err, ErrPredictionsUnsupported)
+
+	_, err = f.DecodeBSON(nil)
+	assert.ErrorIs(t, err, ErrPredictionsUnsupported)
+}


### PR DESCRIPTION
## Summary

Migrates the standalone cron scrapers (VRS tracker + upcoming/current tournament fetcher) into this repo as in-process background jobs, and adds tournament format detection so `/config` knows each tournament's bracket type. Targets `v4`.

## What's included (4 commits)

**1. In-process ingestion (`ingest` package)** — `scripts/dataseeding` folded into the app as two goroutines launched from `main.go`:
- `TournamentSync` (hourly): refreshes the tournament catalog from PandaScore upcoming + running, upserts active tournaments, sweeps dropped ones to `is_finished`. Gates on the app's PandaScore rate limiter (`App.Wait`) so it shares one API budget with the live poller.
- `VRSSync` (hourly): refreshes VRS rankings from the public GitHub snapshot; no-ops when the snapshot date is unchanged.
- Fetch/parse live in `sources`, DB writes in `store` (`SyncTournaments`, `SyncStandings`); `App.Wait` added alongside `App.Allow` (blocking vs non-blocking on the shared limiter).

**2. Tournament format detection** — classifies swiss / single-elimination / double-elimination / other from the PandaScore **bracket graph** (`previous_matches` edges), not match-name text:
- loser edge -> double-elim; winner-only -> single-elim; no edges -> group (round-robin if `n*(n-1)/2` matches, else swiss); empty -> other.
- Runs best-effort in the background on `/config set-tournament` / `set-round`, storing the result on the tournament row.
- Validated against real `/brackets` payloads for all four shapes.

**3. Unsupported-format handling** — a null-object format registered for double-elim/other: read-only features (schedule, results data) keep working, while `/set` refuses cleanly with "the selected tournament uses a format that does not support predictions" instead of erroring on an unknown format.

## Testing

- `go build ./...`, `go vet`, golint, staticcheck all clean.
- Unit + `-tags=integration` store tests pass. New tests: `DetectKindFromBracket`, `SyncTournaments`, `SyncStandings`, the null-object format, and a real round-robin `/brackets` fixture.
- Format writing verified end-to-end (set-tournament updates `format` in the DB).
- Pre-existing repo-wide 80% coverage gate is still not met (unchanged by this work).

## Follow-ups (not in this PR)

- `/results` needs a fallback renderer for double-elim/other (display gap; predictions are already handled).
- The detection hook (`sources.GetPandaScoreBracket`) isn't mockable yet - an automated test needs the fetch behind an interface.
- Renderer/Mongo-era Dockerfile + docker-compose leftovers -> tracked under the PickemsV4 cleanup ticket.
- Poller rework (subscription pool derived from `guild_config`) is the next branch; it must tolerate a NULL/undetected format.
